### PR TITLE
Add prod app settings with default OpenTelemetry log level

### DIFF
--- a/CSIDE.API/appsettings.Production.json
+++ b/CSIDE.API/appsettings.Production.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    },
+    "OpenTelemetry": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/CSIDE.Web/appsettings.Production.json
+++ b/CSIDE.Web/appsettings.Production.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    },
+    "OpenTelemetry": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
This PR adds an appsettings.Production.json file and sets the default OpenTelemetry logging level to "Warning" for more sensible production logging.