### PR TITLE
Fix issue with geom column name introduced when EF naming conventions were changed

### DIFF
--- a/CSIDE.Data/Services/SharedDataService.cs
+++ b/CSIDE.Data/Services/SharedDataService.cs
@@ -155,7 +155,7 @@ namespace CSIDE.Data.Services
         }
         public async Task<PointGeometryResult?> TransformCoordinates(double x, double y, int fromCrs, int toCrs, CancellationToken ct = default)
         {
-            var sql = @"SELECT ST_Transform(ST_SetSRID(ST_MakePoint({0}, {1}), {2}), {3}) AS ""Geom""";
+            var sql = @"SELECT ST_Transform(ST_SetSRID(ST_MakePoint({0}, {1}), {2}), {3}) AS geom";
 
             await using var context = await contextFactory.CreateDbContextAsync(ct);
             return await context.Database


### PR DESCRIPTION
When the Postgres Naming Conventions were applied to EF Core, this caused the SQL in `TransformCoordinates' to start to fail, as this used a specific uppercased name, which no longer translated properly.