### PR TITLE
Ensure only active routes are used in route selections and add legal status search

### DIFF
--- a/CSIDE.Data/EntitiesConfiguration/LegalStatusConfiguration.cs
+++ b/CSIDE.Data/EntitiesConfiguration/LegalStatusConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore;
+using CSIDE.Data.Models.RightsOfWay;
+
+namespace CSIDE.Data.EntitiesConfiguration
+{
+    internal sealed class LegalStatusConfiguration : IEntityTypeConfiguration<LegalStatus>
+    {
+        public void Configure(EntityTypeBuilder<LegalStatus> builder)
+        {
+            builder.Property(x => x.IsActive).HasDefaultValue(true);
+        }
+    }
+}

--- a/CSIDE.Data/Migrations/20260413163042_AddActiveBooleanToRouteLegalStatus.Designer.cs
+++ b/CSIDE.Data/Migrations/20260413163042_AddActiveBooleanToRouteLegalStatus.Designer.cs
@@ -5,6 +5,7 @@ using CSIDE.Data;
 using CSIDE.Data.Models.Surveys;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using NodaTime;
@@ -15,9 +16,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CSIDE.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413163042_AddActiveBooleanToRouteLegalStatus")]
+    partial class AddActiveBooleanToRouteLegalStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CSIDE.Data/Migrations/20260413163042_AddActiveBooleanToRouteLegalStatus.cs
+++ b/CSIDE.Data/Migrations/20260413163042_AddActiveBooleanToRouteLegalStatus.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CSIDE.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddActiveBooleanToRouteLegalStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_active",
+                schema: "cside",
+                table: "route_legal_statuses",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "is_active",
+                schema: "cside",
+                table: "route_legal_statuses");
+        }
+    }
+}

--- a/CSIDE.Data/Models/RightsOfWay/LegalStatus.cs
+++ b/CSIDE.Data/Models/RightsOfWay/LegalStatus.cs
@@ -4,5 +4,6 @@
     {
         public int Id { get; set; }
         public required string Name { get; set; }
+        public required bool IsActive { get; set; }
     }
 }

--- a/CSIDE.Data/Models/RightsOfWay/Search.cs
+++ b/CSIDE.Data/Models/RightsOfWay/Search.cs
@@ -7,6 +7,7 @@
         public string[]? ParishIds { get; set; } = [];
         public string? ParishId { get; set; }
         public int? OperationalStatusId { get; set; }
+        public int? LegalStatusId { get; set; }
         public int? RouteTypeId { get; set; }
         public int? MaintenanceTeamId { get; set; }
     }

--- a/CSIDE.Data/Services/IRightsOfWayService.cs
+++ b/CSIDE.Data/Services/IRightsOfWayService.cs
@@ -19,6 +19,7 @@ namespace CSIDE.Data.Services
             string? ParishId,
             string? MaintenanceTeamId,
             string? OperationalStatusId,
+            string? LegalStatusId,
             string? RouteTypeId,
             string OrderBy = "RouteId",
             ListSortDirection OrderDirection = ListSortDirection.Descending,

--- a/CSIDE.Data/Services/RightsOfWayService.cs
+++ b/CSIDE.Data/Services/RightsOfWayService.cs
@@ -23,6 +23,7 @@ public class RightsOfWayService(IDbContextFactory<ApplicationDbContext> contextF
             { "MaintenanceTeam", x => x.MaintenanceTeam.Name ?? string.Empty },
             { "Name", x => x.Name ?? string.Empty },
             { "OperationalStatus", x => x.OperationalStatus.Name ?? string.Empty },
+            { "LegalStatus", x=> x.LegalStatus.Name ?? string.Empty  },
             { "RouteType", x => x.RouteType.Name ?? string.Empty },
             { "Notes", x => x.Notes ?? string.Empty }
 

--- a/CSIDE.Data/Services/RightsOfWayService.cs
+++ b/CSIDE.Data/Services/RightsOfWayService.cs
@@ -48,22 +48,40 @@ public class RightsOfWayService(IDbContextFactory<ApplicationDbContext> contextF
         return results.Take(1).FirstOrDefault();
     }
 
+    /// <summary>
+    /// Gets the {maxRoutes} nearest active routes within {maxDistance} metres from {geometry}
+    /// </summary>
+    /// <remarks>This only returns routes that have an active legal status. Inactive routes are NOT included</remarks>
+    /// <param name="geometry">The Geometry to use as the source</param>
+    /// <param name="maxDistance">The maximium distance, in metres, that should be checked</param>
+    /// <param name="maxRoutes">The maximum number of routes to return</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>A collection of routes</returns>
     public async Task<ICollection<Route>> GetNearestRoutes(Geometry geometry, int maxDistance = 50, int maxRoutes = 50, CancellationToken ct = default)
     {
         await using var context = await contextFactory.CreateDbContextAsync(ct);
         return await context.Routes
                 .Where(i => i.Geom.IsWithinDistance(geometry, maxDistance))
+                .Where(i => i.LegalStatus!.IsActive)
                 .OrderBy(i => i.Geom.Distance(geometry))
                 .Take(maxRoutes)
                 .ToListAsync(cancellationToken: ct)
                 .ConfigureAwait(false);
     }
 
-    public async Task<ICollection<Geometry>> GetRoutesIntersecting(Polygon bboxPolygon, CancellationToken ct = default)
+    /// <summary>
+    /// Gets all active routes within {polygon}
+    /// </summary>
+    /// <remarks>This only returns routes that have an active legal status. Inactive routes are NOT included</remarks>
+    /// <param name="polygon">The Polygon geometry to find routes within</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>A collection of routes</returns>
+    public async Task<ICollection<Geometry>> GetRoutesIntersecting(Polygon polygon, CancellationToken ct = default)
     {
         await using var context = await contextFactory.CreateDbContextAsync(ct);
         return await context.Routes
-                .Where(i => i.Geom.Intersects(bboxPolygon))
+                .Where(i => i.Geom.Intersects(polygon))
+                .Where(i => i.LegalStatus!.IsActive)
                 .Select(r => r.Geom)
                 .ToArrayAsync(cancellationToken: ct)
                 .ConfigureAwait(false);
@@ -84,6 +102,7 @@ public class RightsOfWayService(IDbContextFactory<ApplicationDbContext> contextF
         string? ParishId,
         string? MaintenanceTeamId,
         string? OperationalStatusId,
+        string? LegalStatusId,
         string? RouteTypeId,
         string OrderBy = "RouteId",
         ListSortDirection OrderDirection = ListSortDirection.Descending,
@@ -100,6 +119,7 @@ public class RightsOfWayService(IDbContextFactory<ApplicationDbContext> contextF
             .Include(r => r.Parish)
             .Include(r => r.MaintenanceTeam)
             .Include(r => r.OperationalStatus)
+            .Include(r => r.LegalStatus)
             .Include(r => r.RouteType)
             .AsQueryable();
 
@@ -133,6 +153,10 @@ public class RightsOfWayService(IDbContextFactory<ApplicationDbContext> contextF
         if (OperationalStatusId is not null && int.TryParse(OperationalStatusId, CultureInfo.InvariantCulture, out int parsedOperationalStatusId))
         {
             query = query.Where(j => j.OperationalStatusId == parsedOperationalStatusId);
+        }
+        if (LegalStatusId is not null && int.TryParse(LegalStatusId, CultureInfo.InvariantCulture, out int parsedLegalStatusId))
+        {
+            query = query.Where(j => j.LegalStatusId == parsedLegalStatusId);
         }
         if (RouteTypeId is not null && int.TryParse(RouteTypeId, CultureInfo.InvariantCulture, out int parsedRouteTypeId))
         {

--- a/CSIDE.Data/Validators/RightsOfWay/SearchValidator.cs
+++ b/CSIDE.Data/Validators/RightsOfWay/SearchValidator.cs
@@ -18,6 +18,7 @@ namespace CSIDE.Data.Validators.RightsOfWay
                 s.ParishIds?.Length != 0 ||
                 s.RouteTypeId.HasValue ||
                 s.OperationalStatusId.HasValue ||
+                s.LegalStatusId.HasValue ||
                 s.MaintenanceTeamId.HasValue)
                 .WithMessage(_localizer["Search Validation At Least One Message"]);
 

--- a/CSIDE.Shared/Properties/Resources.Designer.cs
+++ b/CSIDE.Shared/Properties/Resources.Designer.cs
@@ -2464,6 +2464,15 @@ namespace CSIDE.Shared.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This route is no longer active.
+        /// </summary>
+        public static string Inactive_Route_Warning_Text {
+            get {
+                return ResourceManager.GetString("Inactive Route Warning Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Incomplete surveys.
         /// </summary>
         public static string Incomplete_Surveys_Title {

--- a/CSIDE.Shared/Properties/Resources.cy.resx
+++ b/CSIDE.Shared/Properties/Resources.cy.resx
@@ -1823,4 +1823,7 @@ Creu Blaendal Perchennog Tir newydd gan ddefnyddio map</value>
   <data name="No Order Summary Info Available Message" xml:space="preserve">
     <value>Dim gwybodaeth gryno ar gael. Cliciwch 'Gweld manylion' i weld rhagor o wybodaeth am y gorchymyn hwn.</value>
   </data>
+  <data name="Inactive Route Warning Text" xml:space="preserve">
+    <value>Nid yw'r llwybr hwn yn weithredol mwyach</value>
+  </data>
 </root>

--- a/CSIDE.Shared/Properties/Resources.resx
+++ b/CSIDE.Shared/Properties/Resources.resx
@@ -1812,4 +1812,7 @@
   <data name="No Order Summary Info Available Message" xml:space="preserve">
     <value>No summary information available. Click 'View details' to view further information about this order.</value>
   </data>
+  <data name="Inactive Route Warning Text" xml:space="preserve">
+    <value>This route is no longer active</value>
+  </data>
 </root>

--- a/CSIDE.Web/Components/Pages/RightsOfWay/Details.razor
+++ b/CSIDE.Web/Components/Pages/RightsOfWay/Details.razor
@@ -50,6 +50,11 @@ else
             }
         }
 
+        if(Route.LegalStatus is not null && !Route.LegalStatus.IsActive)
+        {
+            <div class="alert alert-warning"><i class="bi bi-exclamation-triangle"></i> @localizer["Inactive Route Warning Text"]</div>
+        }
+
         <AuthorizeView Roles="Administrator, RoW Officer, Ranger">
             <a href="rights-of-way/Edit/@(Uri.EscapeDataString(Route.RouteCode))" class="btn btn-primary my-2">@localizer["Edit Label"]</a>
         </AuthorizeView> 

--- a/CSIDE.Web/Components/Pages/RightsOfWay/Index.razor
+++ b/CSIDE.Web/Components/Pages/RightsOfWay/Index.razor
@@ -101,6 +101,21 @@
                 </div>
 
                 <div class="mb-3">
+                    <label class="form-label" for="route-legal-status-search">@localizer["Legal Status Label"]</label>
+                    <InputSelect id="route-legal-status-search" class="form-select" @bind-Value="SearchParams.LegalStatusId">
+                        @if (LegalStatuses is not null)
+                        {
+                            <option value=""></option>
+                            @foreach (var status in LegalStatuses.OrderBy(s => s.Id))
+                            {
+                                <option value="@status.Id">@status.Name</option>
+                            }
+                        }
+
+                    </InputSelect>
+                </div>
+
+                <div class="mb-3">
                     <label class="form-label" for="route-type-search">@localizer["Path Type Label"]</label>
                     <InputSelect id="route-type-search" class="form-select" @bind-Value="SearchParams.RouteTypeId">
                         @if (RouteTypes is not null)

--- a/CSIDE.Web/Components/Pages/RightsOfWay/Index.razor.cs
+++ b/CSIDE.Web/Components/Pages/RightsOfWay/Index.razor.cs
@@ -18,6 +18,7 @@ namespace CSIDE.Web.Components.Pages.RightsOfWay
         private Search? SearchParams;
         private string? RouteIDSearch;
         private IReadOnlyCollection<OperationalStatus> OperationalStatuses { get; set; } = [];
+        private IReadOnlyCollection<LegalStatus> LegalStatuses { get; set; } = [];
         private IReadOnlyCollection<RouteType> RouteTypes { get; set; } = [];
         private IReadOnlyCollection<Data.Models.Maintenance.Team> MaintenanceTeams { get; set; } = [];
         private IReadOnlyCollection<Parish> Parishes { get; set; } = [];
@@ -36,6 +37,7 @@ namespace CSIDE.Web.Components.Pages.RightsOfWay
             ];
 
             OperationalStatuses = await rightsOfWayService.GetOperationalStatusOptions();
+            LegalStatuses = await rightsOfWayService.GetLegalStatusOptions();
             RouteTypes = await rightsOfWayService.GetRouteTypeOptions();
             MaintenanceTeams = await maintenanceJobsService.GetMaintenanceTeams();
             Parishes = await sharedDataService.GetParishes();

--- a/CSIDE.Web/Components/Pages/RightsOfWay/List.razor
+++ b/CSIDE.Web/Components/Pages/RightsOfWay/List.razor
@@ -15,4 +15,5 @@
             ParishId= "@ParishId"
             MaintenanceTeamId= "@MaintenanceTeamId"
             OperationalStatusId= "@OperationalStatusId"
+            LegalStatusId="@LegalStatusId"
             RouteTypeId="@RouteTypeId"></RoutesList>

--- a/CSIDE.Web/Components/Pages/RightsOfWay/List.razor.cs
+++ b/CSIDE.Web/Components/Pages/RightsOfWay/List.razor.cs
@@ -20,6 +20,8 @@ namespace CSIDE.Web.Components.Pages.RightsOfWay
         [SupplyParameterFromQuery]
         private string? OperationalStatusId { get; set; }
         [SupplyParameterFromQuery]
+        private string? LegalStatusId { get; set; }
+        [SupplyParameterFromQuery]
         private string? RouteTypeId { get; set; }
 
         protected override void OnInitialized()

--- a/CSIDE.Web/Components/RightsOfWay/RoutesList.razor
+++ b/CSIDE.Web/Components/RightsOfWay/RoutesList.razor
@@ -36,6 +36,9 @@
         <GridColumn TItem="Route" HeaderText="@localizer["Operational Status Label"]" PropertyName="OperationalStatus" SortKeySelector="item => item.OperationalStatus != null ? item.OperationalStatus.Name : string.Empty" SortString="OperationalStatus">
             @context.OperationalStatus?.Name
         </GridColumn>
+        <GridColumn TItem="Route" HeaderText="@localizer["Legal Status Label"]" PropertyName="LegalStatus" SortKeySelector="item => item.LegalStatus != null ? item.LegalStatus.Name : string.Empty" SortString="LegalStatus">
+            @context.LegalStatus?.Name
+        </GridColumn>
         <GridColumn TItem="Route" HeaderText="@localizer["Path Type Label"]" PropertyName="RouteType" SortKeySelector="item => item.RouteType != null ? item.RouteType.Name : string.Empty" SortString="RouteType">
             @context.RouteType?.Name
         </GridColumn>
@@ -69,6 +72,8 @@
     [Parameter]
     public string? OperationalStatusId { get; set; }
     [Parameter]
+    public string? LegalStatusId { get; set; }
+    [Parameter]
     public string? RouteTypeId { get; set; }
 
     public async Task<GridDataProviderResult<Route>> RoutesDataProvider(GridDataProviderRequest<Route> request)
@@ -90,6 +95,7 @@
             ParishId,
             MaintenanceTeamId,
             OperationalStatusId,
+            LegalStatusId,
             RouteTypeId,
             sortString,
             sortDirection,


### PR DESCRIPTION
This PR adds an `IsActive` boolean to the Route Legal Statuses lookup, which can then be used to make sure only active routes are selected from the route pickers when creating maintenance jobs and adding linked routes to DMMOs/PPOs.

This PR also adds the Legal Status as a searchable option in the Rights of Way search page and surfaces the data on the results page.

Fixes #19 