### PR TITLE
Add prompt to ensure photos are added to completed jobs

### DIFF
--- a/CSIDE.Shared/Properties/Resources.Designer.cs
+++ b/CSIDE.Shared/Properties/Resources.Designer.cs
@@ -3139,6 +3139,15 @@ namespace CSIDE.Shared.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remember to attach a photo of the finished job if you haven&apos;t already..
+        /// </summary>
+        public static string Maintenance_Attach_Photo_On_Completion_Reminder_Text {
+            get {
+                return ResourceManager.GetString("Maintenance Attach Photo On Completion Reminder Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Create new maintenance job.
         /// </summary>
         public static string Maintenance_Create_Title {

--- a/CSIDE.Shared/Properties/Resources.cy.resx
+++ b/CSIDE.Shared/Properties/Resources.cy.resx
@@ -1823,4 +1823,7 @@ Creu Blaendal Perchennog Tir newydd gan ddefnyddio map</value>
   <data name="No Order Summary Info Available Message" xml:space="preserve">
     <value>Dim gwybodaeth gryno ar gael. Cliciwch 'Gweld manylion' i weld rhagor o wybodaeth am y gorchymyn hwn.</value>
   </data>
+  <data name="Maintenance Attach Photo On Completion Reminder Text" xml:space="preserve">
+    <value>Cofiwch atodi llun o'r gwaith gorffenedig os nad ydych chi wedi gwneud hynny eisoes.</value>
+  </data>
 </root>

--- a/CSIDE.Shared/Properties/Resources.resx
+++ b/CSIDE.Shared/Properties/Resources.resx
@@ -1812,4 +1812,7 @@
   <data name="No Order Summary Info Available Message" xml:space="preserve">
     <value>No summary information available. Click 'View details' to view further information about this order.</value>
   </data>
+  <data name="Maintenance Attach Photo On Completion Reminder Text" xml:space="preserve">
+    <value>Remember to attach a photo of the finished job if you haven't already.</value>
+  </data>
 </root>

--- a/CSIDE.Web/Components/Maintenance/JobEditForm.razor
+++ b/CSIDE.Web/Components/Maintenance/JobEditForm.razor
@@ -134,6 +134,10 @@
 
         @if (IsEdit)
         {
+            @if (CompleteDateShown && !DuplicateOfShown)
+            {
+                <div class="alert alert-info">@localizer["Maintenance Attach Photo On Completion Reminder Text"]</div>
+            }
             <button type="submit" class="btn btn-primary" disabled="@IsBusy">@localizer["Update Label"]</button>
             <button type="button" class="btn btn-secondary" disabled="@IsBusy" @onclick="HandleCancel">@localizer["Cancel Label"]</button>
         }


### PR DESCRIPTION
This PR adds a small prompt to the Maintenance Job form that reminds users to add a photo of the completed job.

Its a basic implementation that doesn't try to figure out if the user has already done a photo, its just a reminder.

Closes #4 