### PR TITLE
Revert custom http client added to graph calls

### DIFF
--- a/CSIDE.Data/Services/UserService.cs
+++ b/CSIDE.Data/Services/UserService.cs
@@ -108,8 +108,6 @@ namespace CSIDE.Data.Services
 
         private GraphServiceClient? GetGraphClient()
         {
-            const string graphClientName = "MicrosoftGraphResilient";
-
             AzureAdOptions AzureAdOptions = csideOptions.Value.AzureAd;
             if (!string.IsNullOrEmpty(AzureAdOptions.ClientId))
             {
@@ -128,8 +126,7 @@ namespace CSIDE.Data.Services
                 var clientSecretCredential = new ClientSecretCredential(
                     tenantId, clientId, clientSecret, options);
 
-                var httpClient = httpClientFactory.CreateClient(graphClientName);
-                var graphClient = new GraphServiceClient(httpClient, clientSecretCredential, scopes);
+                var graphClient = new GraphServiceClient(clientSecretCredential, scopes);
 
                 return graphClient;
             }

--- a/CSIDE.Data/Services/UserService.cs
+++ b/CSIDE.Data/Services/UserService.cs
@@ -13,7 +13,6 @@ namespace CSIDE.Data.Services
     public class UserService(IDbContextFactory<ApplicationDbContext> contextFactory,
                              IMemoryCache memoryCache,
                              IOptions<CSIDEOptions> csideOptions,
-                             IHttpClientFactory httpClientFactory,
                              ILogger<UserService> logger) : IUserService
     {
         public async Task<List<Microsoft.Graph.Beta.Models.User>> GetUsers()


### PR DESCRIPTION
This PR reverts recent changes to add a custom http client to Microsoft Graph Calls due to errors it appeared to cause.