### PR TITLE
Add help docs link and make language selector optional

### DIFF
--- a/CSIDE.Shared/Options/CSIDEOptions.cs
+++ b/CSIDE.Shared/Options/CSIDEOptions.cs
@@ -24,4 +24,6 @@ public record CSIDEOptions
     public string LandownerDepositsPublicRegisterURL { get; init; } = "";
     public string PublicMaintenanceJobURL { get; init; } = "";
     public string PublicUnsubscribeURL { get; init; } = "";
+    public string HelpDocsURL { get; init; } = "";
+    public bool ShowLanguageSwitcher { get; init; }
 }

--- a/CSIDE.Shared/Properties/Resources.Designer.cs
+++ b/CSIDE.Shared/Properties/Resources.Designer.cs
@@ -2428,6 +2428,15 @@ namespace CSIDE.Shared.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Help.
+        /// </summary>
+        public static string Help_Link_Label {
+            get {
+                return ResourceManager.GetString("Help Link Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hide previous statements.
         /// </summary>
         public static string Hide_Previous_Statements_Label {

--- a/CSIDE.Shared/Properties/Resources.cy.resx
+++ b/CSIDE.Shared/Properties/Resources.cy.resx
@@ -1829,4 +1829,7 @@ Creu Blaendal Perchennog Tir newydd gan ddefnyddio map</value>
   <data name="Maintenance Attach Photo On Completion Reminder Text" xml:space="preserve">
     <value>Cofiwch atodi llun o'r gwaith gorffenedig os nad ydych chi wedi gwneud hynny eisoes.</value>
   </data>
+  <data name="Help Link Label" xml:space="preserve">
+    <value>Cymorth</value>
+  </data>
 </root>

--- a/CSIDE.Shared/Properties/Resources.resx
+++ b/CSIDE.Shared/Properties/Resources.resx
@@ -1818,4 +1818,7 @@
   <data name="Maintenance Attach Photo On Completion Reminder Text" xml:space="preserve">
     <value>Remember to attach a photo of the finished job if you haven't already.</value>
   </data>
+  <data name="Help Link Label" xml:space="preserve">
+    <value>Help</value>
+  </data>
 </root>

--- a/CSIDE.Web/Components/Layout/HelpLink.razor
+++ b/CSIDE.Web/Components/Layout/HelpLink.razor
@@ -2,7 +2,7 @@
 
 @if (!string.IsNullOrEmpty(HelpLinkUrl))
 {
-    <a href="@HelpLinkUrl" target="_blank" class="nav-link ms-3" title="@localizer["Help Link Label"]">
+    <a href="@HelpLinkUrl" target="_blank" rel="noopener noreferrer" class="nav-link ms-3" title="@localizer["Help Link Label"]" aria-label="@localizer["Help Link Label"]">
         <i class="bi bi-question-circle"></i> <span class="d-sm-none d-md-inline d-none">@localizer["Help Link Label"]</span>
     </a>
 }

--- a/CSIDE.Web/Components/Layout/HelpLink.razor
+++ b/CSIDE.Web/Components/Layout/HelpLink.razor
@@ -1,0 +1,17 @@
+﻿@inject IOptions<CSIDEOptions> csideOptions
+
+@if (!string.IsNullOrEmpty(HelpLinkUrl))
+{
+    <a href="@HelpLinkUrl" target="_blank" class="nav-link ms-3" title="@localizer["Help Link Label"]">
+        <i class="bi bi-question-circle"></i> <span class="d-sm-none d-md-inline d-none">@localizer["Help Link Label"]</span>
+    </a>
+}
+
+@code {
+    private string HelpLinkUrl = "";
+    protected override void OnInitialized()
+    {
+        //get help link from appsettings
+        HelpLinkUrl = csideOptions.Value.HelpDocsURL;
+    }
+}

--- a/CSIDE.Web/Components/Layout/MainLayout.razor
+++ b/CSIDE.Web/Components/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
 ﻿@inherits LayoutComponentBase
 @inject IHostEnvironment HostEnvironment
+@inject IOptions<CSIDEOptions> csideOptions
 
 <div class="page flex-row">
     <div class="sidebar">
@@ -8,14 +9,20 @@
 
     <main class="flex-grow-1">
         <div class="top-row px-4">
-            <CultureSelector></CultureSelector>
-            <ThemeSwitcher Position="DropdownMenuPosition.End" Class="ms-2" />
+            @if (csideOptions.Value.ShowLanguageSwitcher)
+            {
+                <div class="ms-3">
+                    <CultureSelector></CultureSelector>
+                </div>
+            }
+            <HelpLink></HelpLink>
+            <ThemeSwitcher Position="DropdownMenuPosition.End" Class="ms-3" />
             <AuthorizeView Policy="AuthenticatedOnly">
                 <Authorized>
-                    <ul class="navbar-nav ps-3">
+                    <ul class="navbar-nav ms-3">
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" aria-expanded="false">
-                                <i class="bi bi-person-circle"></i> @context.User.DisplayName
+                                <i class="bi bi-person-circle"></i> <span class="d-sm-none d-md-inline d-none">@context.User.DisplayName</span>
                             </a>
                             <ul class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
                                 <li><h6 class="dropdown-header">@(context.User.Email ?? "")</h6></li>

--- a/CSIDE.Web/Components/Layout/MainLayout.razor
+++ b/CSIDE.Web/Components/Layout/MainLayout.razor
@@ -21,7 +21,7 @@
                 <Authorized>
                     <ul class="navbar-nav ms-3">
                         <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" aria-expanded="false">
+                            <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" aria-expanded="false" aria-label="@context.User.DisplayName">
                                 <i class="bi bi-person-circle"></i> <span class="d-sm-none d-md-inline d-none">@context.User.DisplayName</span>
                             </a>
                             <ul class="dropdown-menu dropdown-menu-end" data-bs-popper="static">

--- a/CSIDE.Web/appsettings.json
+++ b/CSIDE.Web/appsettings.json
@@ -14,6 +14,8 @@
     "LandownerDepositsPublicRegisterURL": "",
     "PublicUnsubscribeURL": "",
     "PublicMaintenanceJobURL": "",
+    "HelpDocsURL": "",
+    "ShowLanguageSwitcher": true,
     "Database": {
       "Schema": "cside"
     },

--- a/CSIDE.Web/wwwroot/app.css
+++ b/CSIDE.Web/wwwroot/app.css
@@ -59,6 +59,9 @@ a, .btn-link {
 #bb-theme {
   color: var(--bs-nav-link-color)
 }
+#bb-theme-text {
+  display: none;
+}
 .form-label {
   font-weight: 500;
 }

--- a/CSIDE.sln
+++ b/CSIDE.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.3.11408.92 d18.3
+VisualStudioVersion = 18.3.11408.92
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSIDE.Web", "CSIDE.Web\CSIDE.Web.csproj", "{09A92F08-1D5B-493B-8925-85CACA91DCC8}"
 EndProject


### PR DESCRIPTION
This PR adds a link to the help documentation if defined in an app setting, and makes the language selector optional through an app setting.

It also fixes some of the header bar classes to make them more consistent, reorders the options, and ensures text is shown appropriately at different screen sizes. The Theme Selector text has ben explicitly hidden as the default class set in the libraries component (which was not overridable) was the wrong way round, showing the text when screen size was small and hiding it when it was big.