### PR TITLE
Add missing app setting and default to code

### DIFF
--- a/CSIDE.Web/appsettings.json
+++ b/CSIDE.Web/appsettings.json
@@ -67,7 +67,8 @@
       "SignedOutCallbackPath": "",
       "SignUpSignInPolicyId": "",
       "TenantId": "",
-      "Authority": ""
+      "Authority": "",
+      "ResponseType": "code"
     },
     "AzureAI": {
       "LanguageEndpoint": "",


### PR DESCRIPTION
The ResponseType app setting was missing, meaning DevOps release variable replacement didn't work on it. Defaulted the value to code for simplicity