### PR TITLE
Added council decision component

### DIFF
--- a/CSIDE.Data/ApplicationDbContext.cs
+++ b/CSIDE.Data/ApplicationDbContext.cs
@@ -46,6 +46,7 @@ namespace CSIDE.Data
         public DbSet<Models.DMMO.ApplicationClaimedStatus> DMMOApplicationClaimedStatuses { get; set; }
         public DbSet<Models.DMMO.ApplicationType> DMMOApplicationTypes { get; set; }
         public DbSet<Models.DMMO.ApplicationDirectionOfSecState> DMMOApplicationDirectionsOfSecState { get; set; }
+        public DbSet<CouncilDecisionType> DMMOCouncilDecisionTypes { get; set; }
 
         public DbSet<DMMOMedia> DMMOMedia { get; set; }
         public DbSet<DMMOClaimedStatus> DMMOClaimedStatuses { get; set; }
@@ -55,6 +56,7 @@ namespace CSIDE.Data
         public DbSet<DMMOLinkedRoute> DMMOLinkedRoutes { get; set; }
         public DbSet<DMMOOrder> DMMOOrders { get; set; }
         public DbSet<Models.DMMO.DMMOEvent> DMMOEvents { get; set; }
+        public DbSet<DMMOCouncilDecision> DMMOCouncilDecisions { get; set; }
 
         public DbSet<PPOApplication> PPOApplication { get; set; }
         public DbSet<Models.PPO.ApplicationCaseStatus> PPOApplicationCaseStatuses { get; set; }

--- a/CSIDE.Data/EntitiesConfiguration/DMMOApplicationConfiguration.cs
+++ b/CSIDE.Data/EntitiesConfiguration/DMMOApplicationConfiguration.cs
@@ -57,6 +57,10 @@ namespace CSIDE.Data.EntitiesConfiguration
             builder
                 .Navigation(x => x.DMMOApplicationTypes)
                 .AutoInclude();
+
+            builder
+                .Navigation(x => x.DMMOCouncilDecisions)
+                .AutoInclude();
         }
     }
 }

--- a/CSIDE.Data/EntitiesConfiguration/DMMOCouncilDecisionConfiguration.cs
+++ b/CSIDE.Data/EntitiesConfiguration/DMMOCouncilDecisionConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using CSIDE.Data.Models.DMMO;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CSIDE.Data.EntitiesConfiguration
+{
+    internal sealed class DMMOCouncilDecisionConfiguration : IEntityTypeConfiguration<DMMOCouncilDecision>
+    {
+        public void Configure(EntityTypeBuilder<DMMOCouncilDecision> builder)
+        {
+            builder.HasKey(x => new { x.CouncilDecisionId, x.DMMOApplicationId });
+
+            builder
+                .Navigation(x => x.CouncilDecisionType)
+                .AutoInclude();
+
+            builder
+                .Property(x => x.Date)
+                .IsRequired();
+
+            builder.Property(x => x.CouncilDecisionTypeId)
+                .IsRequired();
+
+        }
+    }
+}

--- a/CSIDE.Data/Interceptors/DMMOInterceptor.cs
+++ b/CSIDE.Data/Interceptors/DMMOInterceptor.cs
@@ -32,6 +32,10 @@ internal class DMMOInterceptor : ISaveChangesInterceptor
                 {
                     dmmoOrder.OrderId = await NextOrderId(context, dmmoOrder.DMMOApplicationId, cancellationToken);
                 }
+                else if (entry.Entity is DMMOCouncilDecision dmmoCouncilDecision && entry.State is EntityState.Added)
+                {
+                    dmmoCouncilDecision.CouncilDecisionId = await NextCouncilDecisionId(context, dmmoCouncilDecision.DMMOApplicationId, cancellationToken);
+                }
             }
         }
     }
@@ -78,5 +82,18 @@ internal class DMMOInterceptor : ISaveChangesInterceptor
             .ConfigureAwait(false) ?? 0;
 
         return highestOrderNumber + 1;
+    }
+
+    private static async Task<int> NextCouncilDecisionId(ApplicationDbContext context, int applicationId, CancellationToken cancellationToken)
+    {
+        var highestCouncilDecisionNumber = await context.DMMOCouncilDecisions
+            .AsNoTracking()
+            .IgnoreAutoIncludes()
+            .Where(d => d.DMMOApplicationId == applicationId)
+            .Select(d => (int?)d.CouncilDecisionId)
+            .MaxAsync(cancellationToken)
+            .ConfigureAwait(false) ?? 0;
+
+        return highestCouncilDecisionNumber + 1;
     }
 }

--- a/CSIDE.Data/Migrations/20260506105543_AddCouncilDecisionsToDmmos.Designer.cs
+++ b/CSIDE.Data/Migrations/20260506105543_AddCouncilDecisionsToDmmos.Designer.cs
@@ -5,6 +5,7 @@ using CSIDE.Data;
 using CSIDE.Data.Models.Surveys;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using NodaTime;
@@ -15,9 +16,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CSIDE.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260506105543_AddCouncilDecisionsToDmmos")]
+    partial class AddCouncilDecisionsToDmmos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CSIDE.Data/Migrations/20260506105543_AddCouncilDecisionsToDmmos.cs
+++ b/CSIDE.Data/Migrations/20260506105543_AddCouncilDecisionsToDmmos.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace CSIDE.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCouncilDecisionsToDmmos : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "dmmo_council_decision_types",
+                schema: "cside",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    type = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_dmmo_council_decision_types", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "dmmo_council_decisions",
+                schema: "cside",
+                columns: table => new
+                {
+                    council_decision_id = table.Column<int>(type: "integer", nullable: false),
+                    dmmo_application_id = table.Column<int>(type: "integer", nullable: false),
+                    council_decision_type_id = table.Column<int>(type: "integer", nullable: false),
+                    date = table.Column<LocalDate>(type: "date", nullable: false),
+                    notes = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_dmmo_council_decisions", x => new { x.council_decision_id, x.dmmo_application_id });
+                    table.ForeignKey(
+                        name: "fk_dmmo_council_decisions_dmmo_application_dmmo_application_id",
+                        column: x => x.dmmo_application_id,
+                        principalSchema: "cside",
+                        principalTable: "dmmo_application",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_dmmo_council_decisions_dmmo_council_decision_types_council_",
+                        column: x => x.council_decision_type_id,
+                        principalSchema: "cside",
+                        principalTable: "dmmo_council_decision_types",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dmmo_council_decisions_council_decision_type_id",
+                schema: "cside",
+                table: "dmmo_council_decisions",
+                column: "council_decision_type_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dmmo_council_decisions_dmmo_application_id",
+                schema: "cside",
+                table: "dmmo_council_decisions",
+                column: "dmmo_application_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "dmmo_council_decisions",
+                schema: "cside");
+
+            migrationBuilder.DropTable(
+                name: "dmmo_council_decision_types",
+                schema: "cside");
+        }
+    }
+}

--- a/CSIDE.Data/Models/DMMO/CouncilDecisionType.cs
+++ b/CSIDE.Data/Models/DMMO/CouncilDecisionType.cs
@@ -1,0 +1,8 @@
+﻿namespace CSIDE.Data.Models.DMMO
+{
+    public class CouncilDecisionType
+    {
+        public int Id { get; set; }
+        public required string Type { get; set; }
+    }
+}

--- a/CSIDE.Data/Models/DMMO/DMMOApplication.cs
+++ b/CSIDE.Data/Models/DMMO/DMMOApplication.cs
@@ -41,7 +41,8 @@ namespace CSIDE.Data.Models.DMMO
         public ICollection<DMMOMedia> DMMOMedia { get; } = [];
         public ICollection<DMMOLinkedRoute> DMMOLinkedRoutes { get; } = [];
         public ICollection<DMMOEvent> Events { get; } = [];
-        
+        public ICollection<DMMOCouncilDecision> DMMOCouncilDecisions { get; } = [];
+
         //Concurrency token
         public uint Version { get; set; }
 

--- a/CSIDE.Data/Models/DMMO/DMMOCouncilDecision.cs
+++ b/CSIDE.Data/Models/DMMO/DMMOCouncilDecision.cs
@@ -1,0 +1,18 @@
+﻿using NodaTime;
+
+namespace CSIDE.Data.Models.DMMO
+{
+    public class DMMOCouncilDecision
+    {
+        public int CouncilDecisionId { get; set; }
+        public int DMMOApplicationId { get; set; }
+        public int CouncilDecisionTypeId { get; set; }
+
+        public LocalDate? Date { get; set; }
+        public string? Notes { get; set; }
+
+        public DMMOApplication DMMOApplication { get; set; } = null!;
+        public CouncilDecisionType? CouncilDecisionType { get; set; } = null!;
+
+    }
+}

--- a/CSIDE.Data/Services/DMMOService.cs
+++ b/CSIDE.Data/Services/DMMOService.cs
@@ -199,6 +199,15 @@ public class DMMOService(IDbContextFactory<ApplicationDbContext> contextFactory,
             .FirstOrDefaultAsync(p => p.OrderId == OrderId && p.DMMOApplicationId == ApplicationId, cancellationToken: ct);
     }
 
+    public async Task<DMMOCouncilDecision?> GetCouncilDecisionById(int CouncilDecisionId, int ApplicationId, CancellationToken ct = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(ct);
+        return await context.DMMOCouncilDecisions
+            .AsNoTracking()
+            .Include(p => p.CouncilDecisionType)
+            .FirstOrDefaultAsync(p => p.CouncilDecisionId == CouncilDecisionId && p.DMMOApplicationId == ApplicationId, cancellationToken: ct);
+    }
+
     public async Task<ICollection<DMMOLinkedRoute>> GetDMMOLinkedRoutesByApplicationId(int ApplicationId, CancellationToken ct = default)
     {
         await using var context = await contextFactory.CreateDbContextAsync(ct);
@@ -264,6 +273,16 @@ public class DMMOService(IDbContextFactory<ApplicationDbContext> contextFactory,
             .ToListAsync(ct)
             .ConfigureAwait(false);
     }
+
+    public async Task<ICollection<DMMOCouncilDecision>> GetCouncilDecisionsByApplicationId(int ApplicationId, CancellationToken ct = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(ct);
+        return await context.DMMOCouncilDecisions
+            .Where(o => o.DMMOApplicationId == ApplicationId)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+    }
+
     public async Task<ICollection<DMMOMediaType>> GetDMMOMediaTypes(CancellationToken ct = default)
     {
         //TODO - Cache this
@@ -291,6 +310,16 @@ public class DMMOService(IDbContextFactory<ApplicationDbContext> contextFactory,
         return await context.OrderDeterminationProcesses
                 .AsNoTracking()
                 .OrderBy(p => p.Name)
+                .ToArrayAsync(cancellationToken: ct);
+    }
+
+    public async Task<ICollection<CouncilDecisionType>> GetCouncilDecisionTypeOptions(CancellationToken ct = default)
+    {
+        //TODO - Cache this
+        await using var context = await contextFactory.CreateDbContextAsync(ct);
+        return await context.DMMOCouncilDecisionTypes
+                .AsNoTracking()
+                .OrderBy(p => p.Id)
                 .ToArrayAsync(cancellationToken: ct);
     }
 
@@ -352,6 +381,15 @@ public class DMMOService(IDbContextFactory<ApplicationDbContext> contextFactory,
         await context.SaveChangesAsync(ct);
         return dmmoOrder;
     }
+
+    public async Task<DMMOCouncilDecision> AddCouncilDecisionToDMMO(DMMOCouncilDecision dmmoCouncilDecision, CancellationToken ct = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(ct);
+        context.Add(dmmoCouncilDecision);
+        await context.SaveChangesAsync(ct);
+        return dmmoCouncilDecision;
+    }
+
     public async Task<DMMOApplication> AddMediaToDMMO(DMMOApplication DMMOApplication, DMMOMediaType mediaType, List<Media> UploadedMedia, CancellationToken ct = default)
     {
         await using var context = await contextFactory.CreateDbContextAsync(ct);
@@ -487,6 +525,15 @@ public class DMMOService(IDbContextFactory<ApplicationDbContext> contextFactory,
         return dmmoOrder;
     }
 
+    public async Task<DMMOCouncilDecision> UpdateDMMOCouncilDecision(int CouncilDecisionId, DMMOCouncilDecision dmmoCouncilDecision, CancellationToken ct = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(ct);
+        var existingCouncilDecision = await context.DMMOCouncilDecisions.FindAsync([CouncilDecisionId, dmmoCouncilDecision.DMMOApplicationId], cancellationToken: ct) ?? throw new Exception($"DMMO Council Decision being edited (ID: {CouncilDecisionId}) was not found prior to updating");
+        context.Entry(existingCouncilDecision).CurrentValues.SetValues(dmmoCouncilDecision);
+        await context.SaveChangesAsync(ct).ConfigureAwait(false);
+        return dmmoCouncilDecision;
+    }
+
     public async Task<bool> DeleteDMMOAddress(int ApplicationId, long UPRN, CancellationToken ct = default)
     {
         await using var context = await contextFactory.CreateDbContextAsync(ct);
@@ -518,6 +565,18 @@ public class DMMOService(IDbContextFactory<ApplicationDbContext> contextFactory,
         if (DMMOOrderToDelete is not null)
         {
             context.Remove(DMMOOrderToDelete);
+            await context.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        return true;
+    }
+
+    public async Task<bool> DeleteDMMOCouncilDecision(int ApplicationId, int CouncilDecisionId, CancellationToken ct = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(ct);
+        var DMMOCouncilDecisionToDelete = await context.DMMOCouncilDecisions.FindAsync([CouncilDecisionId, ApplicationId], ct);
+        if (DMMOCouncilDecisionToDelete is not null)
+        {
+            context.Remove(DMMOCouncilDecisionToDelete);
             await context.SaveChangesAsync(ct).ConfigureAwait(false);
         }
         return true;

--- a/CSIDE.Data/Services/IDMMOService.cs
+++ b/CSIDE.Data/Services/IDMMOService.cs
@@ -26,9 +26,11 @@ namespace CSIDE.Data.Services
             int PageSize = IDMMOService.DefaultPageSize,
             CancellationToken ct = default);
         Task<DMMOOrder?> GetDMMOOrderById(int OrderId, int ApplicationId, CancellationToken ct = default);
+        Task<DMMOCouncilDecision?> GetCouncilDecisionById(int CouncilDecisionId, int ApplicationId, CancellationToken ct = default);
         Task<ICollection<DMMOAddress>> GetDMMOAddressesByApplicationId(int ApplicationId, CancellationToken ct = default);
         Task<ICollection<DMMOLinkedRoute>> GetDMMOLinkedRoutesByApplicationId(int ApplicationId, CancellationToken ct = default);
         Task<ICollection<DMMOOrder>> GetDMMOOrdersByApplicationId(int ApplicationId, CancellationToken ct = default);
+        Task<ICollection<DMMOCouncilDecision>> GetCouncilDecisionsByApplicationId(int ApplicationId, CancellationToken ct = default);
         Task<ICollection<DMMOMediaType>> GetDMMOMediaTypes(CancellationToken ct = default);
         Task<ICollection<OrderDecisionOfSecState>> GetOrderDecisionOfSecStateOptions(CancellationToken ct = default);
         Task<ICollection<OrderDeterminationProcess>> GetOrderDeterminationProcessOptions(CancellationToken ct = default);
@@ -36,12 +38,14 @@ namespace CSIDE.Data.Services
         Task<ICollection<ApplicationType>> GetApplicationTypes(CancellationToken ct = default);
         Task<ICollection<ApplicationCaseStatus>> GetCaseStatusOptions(CancellationToken ct = default);
         Task<ICollection<ApplicationDirectionOfSecState>> GetDirectionOfSecStateOptions(CancellationToken ct = default);
-        
+        Task<ICollection<CouncilDecisionType>> GetCouncilDecisionTypeOptions(CancellationToken ct = default);
+
         Task<DMMOApplication> CreateDMMO(DMMOApplication dmmoApplication, List<int> SelectedClaimedStatuses, List<int> SelectedApplicationTypes, CancellationToken ct = default);
         Task<DMMOAddress> AddDMMOAddress(DMMOAddress dmmoAddress, CancellationToken ct = default);
         Task<DMMOLinkedRoute> AddLinkedRouteToDMMO(DMMOLinkedRoute dmmoLinkedRoute, CancellationToken ct = default);
         Task<DMMOEvent> AddEventToDMMO(DMMOEvent dmmoEvent, CancellationToken ct = default);
         Task<DMMOOrder> AddOrderToDMMO(DMMOOrder dmmoOrder, CancellationToken ct = default);
+        Task<DMMOCouncilDecision> AddCouncilDecisionToDMMO(DMMOCouncilDecision dmmoCouncilDecision, CancellationToken ct = default);
         Task<DMMOApplication> AddMediaToDMMO(DMMOApplication DMMOApplication, DMMOMediaType mediaType, List<Media> UploadedMedia, CancellationToken ct = default);
         Task<DMMOContact> AddContactToDMMO(Contact newContact, DMMOApplication dmmoApplication, CancellationToken ct = default);
         Task<DMMOApplication> UpdateDMMO(DMMOApplication dmmoApplication, List<int> SelectedClaimedStatuses, List<int> SelectedApplicationTypes, CancellationToken ct = default);
@@ -50,9 +54,11 @@ namespace CSIDE.Data.Services
 
         Task<DMMOEvent> UpdateDMMOEvent(int id, DMMOEvent dmmoEvent, CancellationToken ct = default);
         Task<DMMOOrder> UpdateDMMOOrder(int OrderId, DMMOOrder dmmoOrder, CancellationToken ct = default);
+        Task<DMMOCouncilDecision> UpdateDMMOCouncilDecision(int CouncilDecisionId, DMMOCouncilDecision dmmoCouncilDecision, CancellationToken ct = default);
         Task<bool> DeleteDMMOAddress(int ApplicationId, long UPRN, CancellationToken ct = default);
         Task<bool> DeleteDMMOLinkedRoute(int ApplicationId, string RouteId, CancellationToken ct = default);
         Task<bool> DeleteDMMOOrder(int ApplicationId, int OrderId, CancellationToken ct = default);
+        Task<bool> DeleteDMMOCouncilDecision(int ApplicationId, int CouncilDecisionId, CancellationToken ct = default);
         Task<bool> DeleteDMMOEvent(int EventId, CancellationToken ct = default);
         Task<bool> AddressExistsOnDMMO(int ApplicationId, long UPRN, CancellationToken ct = default);
         Task<bool> ApplicationExists(int applicationId, CancellationToken ct = default);

--- a/CSIDE.Data/Validators/DMMO/CouncilDecisionValidator.cs
+++ b/CSIDE.Data/Validators/DMMO/CouncilDecisionValidator.cs
@@ -1,0 +1,26 @@
+﻿using FluentValidation;
+using CSIDE.Data.Models.DMMO;
+using Microsoft.Extensions.Localization;
+
+namespace CSIDE.Data.Validators.DMMO
+{
+    public class CouncilDecisionValidator : AbstractValidator<DMMOCouncilDecision>
+    {
+        readonly IStringLocalizer<CSIDE.Shared.Properties.Resources> _localizer;
+        public CouncilDecisionValidator(IStringLocalizer<CSIDE.Shared.Properties.Resources> localizer)
+        {
+            _localizer = localizer;
+            RuleFor(dmmoCouncilDecision => dmmoCouncilDecision.CouncilDecisionType)
+                .NotEmpty()
+                .WithName(_localizer["Council Decision Type Label"]);
+
+            RuleFor(dmmoCouncilDecision => dmmoCouncilDecision.Date)
+                .NotEmpty()
+                .WithName(_localizer["Council Decision Date Label"]);
+
+            RuleFor(dmmoCouncilDecision => dmmoCouncilDecision.Notes)
+                .MaximumLength(4000)
+                .WithName(_localizer["Council Decision Notes Label"]);
+        }
+    }
+}

--- a/CSIDE.Data/Validators/DMMO/CouncilDecisionValidator.cs
+++ b/CSIDE.Data/Validators/DMMO/CouncilDecisionValidator.cs
@@ -15,6 +15,10 @@ namespace CSIDE.Data.Validators.DMMO
                 .NotEmpty()
                 .WithName(_localizer["Council Decision Date Label"]);
 
+            RuleFor(dmmoCouncilDecision => dmmoCouncilDecision.CouncilDecisionTypeId)
+                .NotEmpty()
+                .WithName(_localizer["Council Decision Type Label"]);
+
             RuleFor(dmmoCouncilDecision => dmmoCouncilDecision.Notes)
                 .MaximumLength(4000)
                 .WithName(_localizer["Council Decision Notes Label"]);

--- a/CSIDE.Data/Validators/DMMO/CouncilDecisionValidator.cs
+++ b/CSIDE.Data/Validators/DMMO/CouncilDecisionValidator.cs
@@ -10,9 +10,6 @@ namespace CSIDE.Data.Validators.DMMO
         public CouncilDecisionValidator(IStringLocalizer<CSIDE.Shared.Properties.Resources> localizer)
         {
             _localizer = localizer;
-            RuleFor(dmmoCouncilDecision => dmmoCouncilDecision.CouncilDecisionType)
-                .NotEmpty()
-                .WithName(_localizer["Council Decision Type Label"]);
 
             RuleFor(dmmoCouncilDecision => dmmoCouncilDecision.Date)
                 .NotEmpty()

--- a/CSIDE.Shared/Properties/Resources.Designer.cs
+++ b/CSIDE.Shared/Properties/Resources.Designer.cs
@@ -205,6 +205,15 @@ namespace CSIDE.Shared.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add council decision.
+        /// </summary>
+        public static string Add_Council_Decision_Label {
+            get {
+                return ResourceManager.GetString("Add Council Decision Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add event.
         /// </summary>
         public static string Add_Event_Label {
@@ -1699,6 +1708,42 @@ namespace CSIDE.Shared.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Decision date.
+        /// </summary>
+        public static string Council_Decision_Date_Label {
+            get {
+                return ResourceManager.GetString("Council Decision Date Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Notes.
+        /// </summary>
+        public static string Council_Decision_Notes_Label {
+            get {
+                return ResourceManager.GetString("Council Decision Notes Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Decision type.
+        /// </summary>
+        public static string Council_Decision_Type_Label {
+            get {
+                return ResourceManager.GetString("Council Decision Type Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Council decisions ({0}).
+        /// </summary>
+        public static string Council_Decisions_Label {
+            get {
+                return ResourceManager.GetString("Council Decisions Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Council-owned land affected?.
         /// </summary>
         public static string Council_Land_Affected_Label {
@@ -1902,6 +1947,15 @@ namespace CSIDE.Shared.Properties {
         public static string Delete_Contact_Confirmation {
             get {
                 return ResourceManager.GetString("Delete Contact Confirmation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to delete this council decision?.
+        /// </summary>
+        public static string Delete_Council_Decision_Confirmation {
+            get {
+                return ResourceManager.GetString("Delete Council Decision Confirmation", resourceCulture);
             }
         }
         
@@ -3495,6 +3549,24 @@ namespace CSIDE.Shared.Properties {
         public static string No_Contacts_Message {
             get {
                 return ResourceManager.GetString("No Contacts Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No summary information available.
+        /// </summary>
+        public static string No_Council_Decision_Summary_Info_Available_Message {
+            get {
+                return ResourceManager.GetString("No Council Decision Summary Info Available Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No council decisions.
+        /// </summary>
+        public static string No_Council_Decisions_Message {
+            get {
+                return ResourceManager.GetString("No Council Decisions Message", resourceCulture);
             }
         }
         

--- a/CSIDE.Shared/Properties/Resources.cy.resx
+++ b/CSIDE.Shared/Properties/Resources.cy.resx
@@ -1829,4 +1829,28 @@ Creu Blaendal Perchennog Tir newydd gan ddefnyddio map</value>
   <data name="Maintenance Attach Photo On Completion Reminder Text" xml:space="preserve">
     <value>Cofiwch atodi llun o'r gwaith gorffenedig os nad ydych chi wedi gwneud hynny eisoes.</value>
   </data>
+  <data name="Council Decisions Label" xml:space="preserve">
+    <value>Penderfyniadau'r cyngor ({0})</value>
+  </data>
+  <data name="Council Decision Date Label" xml:space="preserve">
+    <value>Dyddiad y penderfyniad</value>
+  </data>
+  <data name="Council Decision Type Label" xml:space="preserve">
+    <value>Math o benderfyniad</value>
+  </data>
+  <data name="Council Decision Notes Label" xml:space="preserve">
+    <value>Nodiadau</value>
+  </data>
+  <data name="Add Council Decision Label" xml:space="preserve">
+    <value>Ychwanegu penderfyniad cyngor</value>
+  </data>
+  <data name="No Council Decision Summary Info Available Message" xml:space="preserve">
+    <value>Dim gwybodaeth grynodeb ar gael</value>
+  </data>
+  <data name="Delete Council Decision Confirmation" xml:space="preserve">
+    <value>Ydych chi'n siŵr eich bod chi am ddileu'r penderfyniad cyngor hwn?</value>
+  </data>
+  <data name="No Council Decisions Message" xml:space="preserve">
+    <value>Dim penderfyniadau cyngor</value>
+  </data>
 </root>

--- a/CSIDE.Shared/Properties/Resources.resx
+++ b/CSIDE.Shared/Properties/Resources.resx
@@ -1818,4 +1818,28 @@
   <data name="Maintenance Attach Photo On Completion Reminder Text" xml:space="preserve">
     <value>Remember to attach a photo of the finished job if you haven't already.</value>
   </data>
+  <data name="Council Decisions Label" xml:space="preserve">
+    <value>Council decisions ({0})</value>
+  </data>
+  <data name="Council Decision Date Label" xml:space="preserve">
+    <value>Decision date</value>
+  </data>
+  <data name="Council Decision Type Label" xml:space="preserve">
+    <value>Decision type</value>
+  </data>
+  <data name="Council Decision Notes Label" xml:space="preserve">
+    <value>Notes</value>
+  </data>
+  <data name="Add Council Decision Label" xml:space="preserve">
+    <value>Add council decision</value>
+  </data>
+  <data name="No Council Decision Summary Info Available Message" xml:space="preserve">
+    <value>No summary information available</value>
+  </data>
+  <data name="Delete Council Decision Confirmation" xml:space="preserve">
+    <value>Are you sure you want to delete this council decision?</value>
+  </data>
+  <data name="No Council Decisions Message" xml:space="preserve">
+    <value>No council decisions</value>
+  </data>
 </root>

--- a/CSIDE.Web/Components/DMMO/CouncilDecisionEditForm.razor
+++ b/CSIDE.Web/Components/DMMO/CouncilDecisionEditForm.razor
@@ -17,7 +17,7 @@
                         DateStringRepresentation = CouncilDecision.Date.Value.ToDateOnly().ToString("yyyy-MM-dd");
                     }
                 }
-                <input id="council-decision-date" type="date" class="form-control" value="@DateStringRepresentation" @onchange="UpdateDateSealedProperty" />
+                <input id="council-decision-date" type="date" class="form-control" value="@DateStringRepresentation" @onchange="UpdateDecisionDateProperty" />
             </div>
             <ValidationMessage For="() => CouncilDecision.Date" />
         </div>

--- a/CSIDE.Web/Components/DMMO/CouncilDecisionEditForm.razor
+++ b/CSIDE.Web/Components/DMMO/CouncilDecisionEditForm.razor
@@ -2,7 +2,7 @@
 
 @if (CouncilDecision is not null)
 {
-    <EditForm Model="CouncilDecision" OnSubmit="@SubmitFormAsync">
+    <EditForm Model="CouncilDecision" OnSubmit="@HandleSubmit">
 
         <FluentValidationValidator @ref="fluentValidationValidator" />
         <ValidationSummary />
@@ -46,16 +46,8 @@
             <ValidationMessage For="() => CouncilDecision.Notes" />
         </div>
 
-        @if (IsEdit)
-        {
-            <button type="submit" class="btn btn-primary" disabled="@IsBusy">@localizer["Update Label"]</button>
-        }
-        else
-        {
-            <button type="submit" class="btn btn-primary" disabled="@IsBusy">@localizer["Create Label"]</button>
-        }
+        <button type="submit" class="btn btn-outline-primary" disabled="@IsBusy">@localizer["Save Label"]</button>
         <button type="button" class="btn btn-link ms-2" disabled="@IsBusy" @onclick="HandleCancel">@localizer["Cancel Label"]</button>
-
 
     </EditForm>
 

--- a/CSIDE.Web/Components/DMMO/CouncilDecisionEditForm.razor
+++ b/CSIDE.Web/Components/DMMO/CouncilDecisionEditForm.razor
@@ -1,0 +1,62 @@
+﻿@using CSIDE.Data.Models.Shared
+
+@if (CouncilDecision is not null)
+{
+    <EditForm Model="CouncilDecision" OnSubmit="@SubmitFormAsync">
+
+        <FluentValidationValidator @ref="fluentValidationValidator" />
+        <ValidationSummary />
+
+        <div class="mb-3 row">
+            <div class=" col-sm-4 col-md-6 col-lg-4">
+                <label class="form-label" for="council-decision-date">@localizer["Council Decision Date Label"]</label>
+                @{
+                    string DateStringRepresentation = "";
+                    if (CouncilDecision.Date.HasValue)
+                    {
+                        DateStringRepresentation = CouncilDecision.Date.Value.ToDateOnly().ToString("yyyy-MM-dd");
+                    }
+                }
+                <input id="council-decision-date" type="date" class="form-control" value="@DateStringRepresentation" @onchange="UpdateDateSealedProperty" />
+            </div>
+            <ValidationMessage For="() => CouncilDecision.Date" />
+        </div>
+
+        <div class="mb-3 row">
+            <div class="col-sm-8 col-lg-6">
+                <label class="form-label" for="council-decision-type">@localizer["Council Decision Type Label"]</label>
+                <InputSelect id="council-decision-type" class="form-select" @bind-Value="CouncilDecision.CouncilDecisionTypeId">
+                    <option value=""></option>
+                    @if (CouncilDecisionTypes is not null)
+                    {
+                        @foreach (var type in CouncilDecisionTypes.OrderBy(s => s.Id))
+                        {
+                            <option value="@type.Id">@type.Type</option>
+                        }
+                    }
+
+                </InputSelect>
+            </div>
+            <ValidationMessage For="() => CouncilDecision.CouncilDecisionTypeId" />
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label" for="council-decision-notes">@localizer["Council Decision Notes Label"]</label>
+            <InputTextArea id="council-decision-notes" class="form-control" @bind-Value="CouncilDecision.Notes"></InputTextArea>
+            <ValidationMessage For="() => CouncilDecision.Notes" />
+        </div>
+
+        @if (IsEdit)
+        {
+            <button type="submit" class="btn btn-primary" disabled="@IsBusy">@localizer["Update Label"]</button>
+        }
+        else
+        {
+            <button type="submit" class="btn btn-primary" disabled="@IsBusy">@localizer["Create Label"]</button>
+        }
+        <button type="button" class="btn btn-link ms-2" disabled="@IsBusy" @onclick="HandleCancel">@localizer["Cancel Label"]</button>
+
+
+    </EditForm>
+
+}

--- a/CSIDE.Web/Components/DMMO/CouncilDecisionEditForm.razor.cs
+++ b/CSIDE.Web/Components/DMMO/CouncilDecisionEditForm.razor.cs
@@ -35,7 +35,7 @@ namespace CSIDE.Web.Components.DMMO
             return await fluentValidationValidator!.ValidateAsync();
         }
 
-        private void UpdateDateSealedProperty(ChangeEventArgs eventArgs)
+        private void UpdateDecisionDateProperty(ChangeEventArgs eventArgs)
         {
             UpdateDateProperty(eventArgs, date => CouncilDecision!.Date = date);
         }

--- a/CSIDE.Web/Components/DMMO/CouncilDecisionEditForm.razor.cs
+++ b/CSIDE.Web/Components/DMMO/CouncilDecisionEditForm.razor.cs
@@ -1,0 +1,73 @@
+﻿using Blazored.FluentValidation;
+using CSIDE.Data.Models.DMMO;
+using CSIDE.Data.Models.Shared;
+using Microsoft.AspNetCore.Components;
+using NodaTime;
+
+namespace CSIDE.Web.Components.DMMO
+{
+    public partial class CouncilDecisionEditForm
+    {
+        [Parameter, EditorRequired]
+        public DMMOCouncilDecision? CouncilDecision { get; set; }
+        [Parameter, EditorRequired]
+        public ICollection<CouncilDecisionType> CouncilDecisionTypes { get; set; }
+        [Parameter]
+        public bool IsBusy { get; set; }
+        [Parameter]
+        public bool IsEdit { get; set; }
+        [Parameter, EditorRequired]
+        public EventCallback OnSubmit { get; set; }
+        [Parameter, EditorRequired]
+        public EventCallback OnCancel { get; set; }
+
+        private FluentValidationValidator? fluentValidationValidator;
+
+        private async Task SubmitFormAsync()
+        {
+            if (OnSubmit.HasDelegate)
+            {
+                await OnSubmit.InvokeAsync();
+            }
+        }
+
+        public async Task<bool> ValidateAsync()
+        {
+            if (!IsEdit)
+            {
+                return await fluentValidationValidator!.ValidateAsync(opts => opts.IncludeAllRuleSets());
+            }
+            return await fluentValidationValidator!.ValidateAsync();
+        }
+
+        private void UpdateDateSealedProperty(ChangeEventArgs eventArgs)
+        {
+            UpdateDateProperty(eventArgs, date => CouncilDecision!.Date = date);
+        }
+
+        private void UpdateDateProperty(ChangeEventArgs eventArgs, Action<LocalDate?> updateProperty)
+        {
+            if (CouncilDecision is not null && eventArgs.Value is not null)
+            {
+                try
+                {
+                    var pattern = NodaTime.Text.LocalDatePattern.CreateWithInvariantCulture("yyyy-MM-dd");
+                    var parseResult = pattern.Parse(eventArgs.Value.ToString()!);
+                    updateProperty(parseResult.Value);
+                }
+                catch (Exception)
+                {
+                    // Problem parsing date, don't update
+                }
+            }
+        }
+
+        private async Task HandleCancel()
+        {
+            if (OnCancel.HasDelegate)
+            {
+                await OnCancel.InvokeAsync();
+            }
+        }
+    }
+}

--- a/CSIDE.Web/Components/DMMO/CouncilDecisionEditForm.razor.cs
+++ b/CSIDE.Web/Components/DMMO/CouncilDecisionEditForm.razor.cs
@@ -1,6 +1,5 @@
 ﻿using Blazored.FluentValidation;
 using CSIDE.Data.Models.DMMO;
-using CSIDE.Data.Models.Shared;
 using Microsoft.AspNetCore.Components;
 using NodaTime;
 
@@ -17,26 +16,22 @@ namespace CSIDE.Web.Components.DMMO
         [Parameter]
         public bool IsEdit { get; set; }
         [Parameter, EditorRequired]
-        public EventCallback OnSubmit { get; set; }
+        public EventCallback<DMMOCouncilDecision> OnSubmit { get; set; }
         [Parameter, EditorRequired]
         public EventCallback OnCancel { get; set; }
 
         private FluentValidationValidator? fluentValidationValidator;
 
-        private async Task SubmitFormAsync()
+        private async Task HandleSubmit()
         {
             if (OnSubmit.HasDelegate)
             {
-                await OnSubmit.InvokeAsync();
+                await OnSubmit.InvokeAsync(CouncilDecision);
             }
         }
 
         public async Task<bool> ValidateAsync()
         {
-            if (!IsEdit)
-            {
-                return await fluentValidationValidator!.ValidateAsync(opts => opts.IncludeAllRuleSets());
-            }
             return await fluentValidationValidator!.ValidateAsync();
         }
 

--- a/CSIDE.Web/Components/DMMO/DMMOCouncilDecisionsList.razor
+++ b/CSIDE.Web/Components/DMMO/DMMOCouncilDecisionsList.razor
@@ -1,0 +1,79 @@
+﻿@using Data.Models.DMMO
+@if (CouncilDecisions is not null)
+{
+    if (IsEditable)
+    {
+        <button type="button" class="btn btn-outline-primary btn-sm" @onclick="() => ShowAddCouncilDecisionModal()">@localizer["Add Council Decision Label"]</button>
+    }
+
+    @if (CouncilDecisions.Count != 0)
+    {
+        <div class="row">
+            @foreach (DMMOCouncilDecision councilDecision in CouncilDecisions.OrderBy(c => c.CouncilDecisionId))
+            {
+                <div class="col-lg-6 my-2">
+                    <div class="card bg-light-subtle h-100" id="council-decision-@councilDecision.CouncilDecisionId">
+                        <div class="card-header">
+                            <strong>@(councilDecision.DMMOApplicationId)/@(councilDecision.CouncilDecisionId)</strong>
+                        </div>
+                        <div class="card-body">
+                            @if (councilDecision.Date.HasValue || councilDecision.CouncilDecisionType.Type is not null || councilDecision.Notes is not null)
+                            {
+                                <ul class="list-unstyled">
+                                    @if (councilDecision.Date.HasValue)
+                                    {
+                                        <li><strong>@localizer["Council Decision Date Label"]</strong>: @councilDecision.Date</li>
+                                    }
+                                    @if (councilDecision.CouncilDecisionType.Type is not null)
+                                    {
+                                        <li><strong>@localizer["Council Decision Type Label"]</strong>: @councilDecision.CouncilDecisionType.Type</li>
+                                    }
+                                    @if (councilDecision.Notes is not null)
+                                    {
+                                        <li><strong>@localizer["Council Decision Notes Label"]</strong>: @councilDecision.Notes</li>
+                                    }
+                                </ul>
+                            }
+                            else
+                            {
+                                <p>@localizer["No Council Decision Summary Info Available Message"]</p>
+                            }
+                        </div>
+                        <div class="card-footer">
+                            @if (IsEditable)
+                            {
+                                <button class="btn btn-sm btn-outline-primary" type="button" disabled="@(IsBusy)" @onclick="() => ShowEditCouncilDecisionModal(councilDecision)">@localizer["Edit Label"]</button>
+                                <button class="btn btn-sm btn-outline-danger" type="button" disabled="@(IsBusy)" @onclick="() => DeleteCouncilDecision(DMMOApplicationId, councilDecision.CouncilDecisionId)">@localizer["Delete Label"]</button>
+                            }
+                        </div>
+                    </div>
+
+                </div>
+            }
+        </div>
+        }
+    else
+    {
+        <Alert Color="AlertColor.Info" Class="mt-2">@localizer["No Council Decisions Message"]</Alert>
+    }
+
+    @if (NewCouncilDecision is not null && IsEditable)
+    {
+        <Modal @ref="AddCouncilDecisionModal" Title="@localizer["Add Council Decision Label"]">
+            <BodyTemplate>
+                @if (ErrorMessage is not null)
+                {
+                    <Alert Color="AlertColor.Danger">@ErrorMessage</Alert>
+                }
+                <CouncilDecisionEditForm CouncilDecision="NewCouncilDecision"
+                                    CouncilDecisionTypes="CouncilDecisionTypes"
+                                    OnSubmit="SubmitFormAsync"
+                                    OnCancel="HideAddCouncilDecisionModal"
+                                    IsBusy="IsBusy"
+                                    IsEdit="IsEdit"
+                                    @ref="NewCouncilDecisionForm" />
+            </BodyTemplate>
+        </Modal>
+    }
+    
+}

--- a/CSIDE.Web/Components/DMMO/DMMOCouncilDecisionsList.razor.cs
+++ b/CSIDE.Web/Components/DMMO/DMMOCouncilDecisionsList.razor.cs
@@ -15,8 +15,6 @@ namespace CSIDE.Web.Components.DMMO
         [Parameter]
         public EventCallback<(DMMOCouncilDecision CouncilDecision, bool IsEdit)> OnSubmit { get; set; }
         [Parameter]
-        public EventCallback OnRefresh { get; set; }
-        [Parameter]
         public bool IsEditable { get; set; } = false;
 
         private DMMOCouncilDecision? NewCouncilDecision { get; set; }

--- a/CSIDE.Web/Components/DMMO/DMMOCouncilDecisionsList.razor.cs
+++ b/CSIDE.Web/Components/DMMO/DMMOCouncilDecisionsList.razor.cs
@@ -13,7 +13,7 @@ namespace CSIDE.Web.Components.DMMO
         [Parameter]
         public int DMMOApplicationId { get; set; }
         [Parameter]
-        public EventCallback<DMMOCouncilDecision> OnSubmit { get; set; }
+        public EventCallback<(DMMOCouncilDecision CouncilDecision, bool IsEdit)> OnSubmit { get; set; }
         [Parameter]
         public EventCallback OnRefresh { get; set; }
         [Parameter]
@@ -46,7 +46,7 @@ namespace CSIDE.Web.Components.DMMO
                 IsBusy = true;
                 if (OnSubmit.HasDelegate)
                 {
-                    await OnSubmit.InvokeAsync(NewCouncilDecision);
+                    await OnSubmit.InvokeAsync((NewCouncilDecision!, IsEdit));
                 }
                 IsBusy = false;
                 await HideAddCouncilDecisionModal();

--- a/CSIDE.Web/Components/DMMO/DMMOCouncilDecisionsList.razor.cs
+++ b/CSIDE.Web/Components/DMMO/DMMOCouncilDecisionsList.razor.cs
@@ -1,0 +1,103 @@
+using BlazorBootstrap;
+using CSIDE.Data.Models.DMMO;
+using CSIDE.Data.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace CSIDE.Web.Components.DMMO
+{
+    public partial class DMMOCouncilDecisionsList(IJSRuntime JS, IDMMOService dmmoService)
+    {
+        [Parameter]
+        public ICollection<DMMOCouncilDecision>? CouncilDecisions { get; set; }
+        [Parameter]
+        public int DMMOApplicationId { get; set; }
+        [Parameter]
+        public EventCallback<DMMOCouncilDecision> OnSubmit { get; set; }
+        [Parameter]
+        public EventCallback OnRefresh { get; set; }
+        [Parameter]
+        public bool IsEditable { get; set; } = false;
+
+        private DMMOCouncilDecision? NewCouncilDecision { get; set; }
+        private ICollection<CouncilDecisionType> CouncilDecisionTypes { get; set; } = [];
+        private bool IsBusy { get; set; }
+        private string? ErrorMessage { get; set; }
+        private CouncilDecisionEditForm? NewCouncilDecisionForm;
+        private bool IsEdit { get; set; }
+
+        private Modal AddCouncilDecisionModal = default!;
+
+        protected override async Task OnParametersSetAsync()
+        {
+            NewCouncilDecision = new();
+            CouncilDecisionTypes = await dmmoService.GetCouncilDecisionTypeOptions();
+        }
+
+        private async Task SubmitFormAsync()
+        {
+            if (IsBusy)
+            {
+                ErrorMessage = null;
+                return;
+            }
+            if (await NewCouncilDecisionForm!.ValidateAsync())
+            {
+                IsBusy = true;
+                if (OnSubmit.HasDelegate)
+                {
+                    await OnSubmit.InvokeAsync(NewCouncilDecision);
+                }
+                IsBusy = false;
+                await HideAddCouncilDecisionModal();
+                await RefreshComponent();
+            }
+        }
+
+        private async Task ShowAddCouncilDecisionModal()
+        {
+            IsEdit = false;
+            NewCouncilDecision = new();
+            await AddCouncilDecisionModal.ShowAsync();
+        }
+
+        private async Task ShowEditCouncilDecisionModal(DMMOCouncilDecision councilDecision)
+        {
+            IsEdit = true;
+            NewCouncilDecision = new()
+            {
+                CouncilDecisionId = councilDecision.CouncilDecisionId,
+                DMMOApplicationId = councilDecision.DMMOApplicationId,
+                CouncilDecisionTypeId = councilDecision.CouncilDecisionTypeId,
+                Date = councilDecision.Date,
+                Notes = councilDecision.Notes,
+            };
+            await AddCouncilDecisionModal.ShowAsync();
+        }
+
+        private async Task HideAddCouncilDecisionModal()
+        {
+            await AddCouncilDecisionModal.HideAsync();
+        }
+
+        private async Task DeleteCouncilDecision(int ApplicationId, int CouncilDecisionId)
+        {
+            IsBusy = true;
+            bool ConfirmDelete = await JS.InvokeAsync<bool>("confirm", localizer["Delete Council Decision Confirmation"].Value);
+            if (ConfirmDelete)
+            {
+                await dmmoService.DeleteDMMOCouncilDecision(ApplicationId, CouncilDecisionId);
+                await RefreshComponent();
+                
+            }
+            IsBusy = false;
+        }
+
+        private async Task RefreshComponent()
+        {
+            CouncilDecisions = await dmmoService.GetCouncilDecisionsByApplicationId(DMMOApplicationId);
+            StateHasChanged();
+        }
+    }
+
+}

--- a/CSIDE.Web/Components/Pages/DMMO/Details.razor
+++ b/CSIDE.Web/Components/Pages/DMMO/Details.razor
@@ -183,6 +183,23 @@ else
                     </ChildContent>
                 </CollapsibleCard>
 
+                <CollapsibleCard Id="dmmo-council-decisions" Title="@localizer["Council Decisions Label", DMMOApplication.DMMOCouncilDecisions.Count]">
+                    <ChildContent>
+                        <ErrorBoundary>
+                            <ChildContent>
+                                <DMMOCouncilDecisionsList CouncilDecisions="DMMOApplication.DMMOCouncilDecisions"
+                                                IsEditable="UserCanEdit"
+                                                DMMOApplicationId="DMMOApplication.Id"
+                                                OnSubmit="SaveCouncilDecision">
+                                </DMMOCouncilDecisionsList>
+                            </ChildContent>
+                            <ErrorContent Context="Exception">
+                                <GenericErrorAlert Exception="Exception"></GenericErrorAlert>
+                            </ErrorContent>
+                        </ErrorBoundary>
+                    </ChildContent>
+                </CollapsibleCard>
+
                 <CollapsibleCard Id="dmmo-contacts" Title="@localizer["Contacts Label",DMMOApplication.DMMOContacts.Count]">
                     <ChildContent>
                         <ErrorBoundary>
@@ -316,6 +333,8 @@ else
     private DMMOApplication? DMMOApplication { get; set; }
 
     private bool IsBusy { get; set; }
+    [Parameter]
+    public bool IsEdit { get; set; }
 
     [CascadingParameter]
     private Task<AuthenticationState>? AuthenticationState { get; set; }
@@ -331,7 +350,8 @@ else
         nameof(Data.Models.DMMO.DMMOOrder),
         nameof(Data.Models.DMMO.DMMOEvent),
         nameof(Data.Models.DMMO.DMMOClaimedStatus),
-        nameof(Data.Models.DMMO.DMMOApplicationType)
+        nameof(Data.Models.DMMO.DMMOApplicationType),
+        nameof(Data.Models.DMMO.DMMOCouncilDecision)
     };
 
     protected override async Task OnParametersSetAsync()
@@ -387,6 +407,26 @@ else
     private async Task RefreshContactsList(){
         DMMOApplication = await dmmoService.GetDMMOApplicationById(Id);
         StateHasChanged();
+    }
+
+    private async Task SaveCouncilDecision(DMMOCouncilDecision councilDecision)
+    {
+        if (councilDecision is not null && DMMOApplication is not null)
+        {
+            councilDecision.DMMOApplicationId = DMMOApplication.Id;
+
+            if (IsEdit == false)
+            {
+                await dmmoService.AddCouncilDecisionToDMMO(councilDecision);
+            }
+            else
+            {
+                await dmmoService.UpdateDMMOCouncilDecision(councilDecision.CouncilDecisionId, councilDecision);
+            }
+
+            DMMOApplication = await dmmoService.GetDMMOApplicationById(Id);
+            StateHasChanged();
+        }
     }
 }
 

--- a/CSIDE.Web/Components/Pages/DMMO/Details.razor
+++ b/CSIDE.Web/Components/Pages/DMMO/Details.razor
@@ -190,7 +190,7 @@ else
                                 <DMMOCouncilDecisionsList CouncilDecisions="DMMOApplication.DMMOCouncilDecisions"
                                                 IsEditable="UserCanEdit"
                                                 DMMOApplicationId="DMMOApplication.Id"
-                                                OnSubmit="SaveCouncilDecision">
+                                                OnSubmit="@(args => SaveCouncilDecision(args.CouncilDecision, args.IsEdit))">
                                 </DMMOCouncilDecisionsList>
                             </ChildContent>
                             <ErrorContent Context="Exception">
@@ -333,8 +333,6 @@ else
     private DMMOApplication? DMMOApplication { get; set; }
 
     private bool IsBusy { get; set; }
-    [Parameter]
-    public bool IsEdit { get; set; }
 
     [CascadingParameter]
     private Task<AuthenticationState>? AuthenticationState { get; set; }
@@ -409,13 +407,13 @@ else
         StateHasChanged();
     }
 
-    private async Task SaveCouncilDecision(DMMOCouncilDecision councilDecision)
+    private async Task SaveCouncilDecision(DMMOCouncilDecision councilDecision, bool isEdit)
     {
         if (councilDecision is not null && DMMOApplication is not null)
         {
             councilDecision.DMMOApplicationId = DMMOApplication.Id;
 
-            if (IsEdit == false)
+            if (isEdit == false)
             {
                 await dmmoService.AddCouncilDecisionToDMMO(councilDecision);
             }


### PR DESCRIPTION
This PR adds a new component for recording council decisions on DMMOs. 

Users can pick a date, decision type and can include optional notes. Multiple decisions can be saved on each DMMO.

Closes #25 

