### PR TITLE
Add defensive HTML decoding to maintenance create API request

### DIFF
--- a/CSIDE.Data/Services/MaintenanceJobsService.cs
+++ b/CSIDE.Data/Services/MaintenanceJobsService.cs
@@ -15,6 +15,7 @@ using NodaTime;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq.Expressions;
+using System.Net;
 
 namespace CSIDE.Data.Services;
 
@@ -654,10 +655,13 @@ public class MaintenanceJobsService(IDbContextFactory<ApplicationDbContext> cont
         var jobStatuses = await GetMaintenanceJobStatuses(ct);
         var jobPriorities = await GetMaintenanceJobPriorities(ct);
 
+        //Some services HTML encode, so decode at this point as a defensive measure
+        var decodedProblemDescription = WebUtility.HtmlDecode(model.ProblemDescription);
+
         return new Job
         {
             RouteId = nearestRoute?.RouteCode,
-            ProblemDescription = model.ProblemDescription,
+            ProblemDescription = decodedProblemDescription,
             LoggedByName = "Public",
             JobStatusId = jobStatuses?.FirstOrDefault()?.Id,
             JobPriorityId = jobPriorities?.FirstOrDefault()?.Id,

--- a/CSIDE.Data/Services/MaintenanceJobsService.cs
+++ b/CSIDE.Data/Services/MaintenanceJobsService.cs
@@ -655,7 +655,7 @@ public class MaintenanceJobsService(IDbContextFactory<ApplicationDbContext> cont
         var jobStatuses = await GetMaintenanceJobStatuses(ct);
         var jobPriorities = await GetMaintenanceJobPriorities(ct);
 
-        //Some services HTML encode, so decode at this point as a defensive measure
+        // Some clients send HTML-encoded text, so decode it here as a defensive measure.
         var decodedProblemDescription = WebUtility.HtmlDecode(model.ProblemDescription);
 
         return new Job


### PR DESCRIPTION
This PR adds a defensive bit of HTML decoding to the Problem Description field in the API endpoint for creating maintenance jobs.

Before, it was expected that JSON would be properly encoded, however, some clients are sending data with HTML encoding (particularly `&#10;` for line breaks). This is then handled as plain text by the API and results in outputs that look like this

`test&#10;&#10;test&#10;&#10;test`

The fix is to decode the problem description, which then fixes this issue.

Ideally clients would behave properly, but in this case that is not possible and a simple defensive fix should cover most cases.