### PR TITLE
Fix various minor bugs

### DIFF
--- a/CSIDE.Data/Interceptors/AuditInterceptor.cs
+++ b/CSIDE.Data/Interceptors/AuditInterceptor.cs
@@ -266,7 +266,7 @@ internal class AuditInterceptor : ISaveChangesInterceptor
             secondaryId = primaryId;
             primaryId = ppoEvent.PPOApplicationId.ToString(CultureInfo.InvariantCulture);
         }
-        if(entry.Entity is JobSubscriber jobSubscriber)
+        if(entry.Entity is JobSubscriber)
         {
             secondaryId = ObscureEmailAddress(secondaryId);
         }
@@ -333,7 +333,7 @@ internal class AuditInterceptor : ISaveChangesInterceptor
                     StringComparer.Ordinal
                 );
         }
-
+        properties = ObscureSensitiveAuditProperties(entry, properties);
         return JsonSerializer.SerializeToDocument(properties, _jsonSerializerOptions);
     }
 
@@ -365,47 +365,8 @@ internal class AuditInterceptor : ISaveChangesInterceptor
                     StringComparer.Ordinal
                 );
         }
-
+        properties = ObscureSensitiveAuditProperties(entry, properties);
         return JsonSerializer.SerializeToDocument(properties, _jsonSerializerOptions);
-    }
-
-    private static ICollection<EntityEntry> GetChildEntities(ApplicationDbContext context, EntityEntry parentEntry)
-    {
-        ICollection<EntityEntry> childEntries = [];
-        var entityType = parentEntry.Metadata;
-
-        foreach (var navigation in entityType.GetNavigations())
-        {
-            if (navigation.IsCollection)
-            {
-                var relatedEntities = context.Entry(parentEntry.Entity).Collection(navigation.Name).CurrentValue;
-                if (relatedEntities != null)
-                {
-                    foreach (var relatedEntity in relatedEntities)
-                    {
-                        var relatedEntry = context.Entry(relatedEntity);
-                        if (relatedEntry.State != EntityState.Detached)
-                        {
-                            childEntries.Add(relatedEntry);
-                        }
-                    }
-                }
-            }
-            else
-            {
-                var relatedEntity = context.Entry(parentEntry.Entity).Reference(navigation.Name).CurrentValue;
-                if (relatedEntity != null)
-                {
-                    var relatedEntry = context.Entry(relatedEntity);
-                    if (relatedEntry.State != EntityState.Detached)
-                    {
-                        childEntries.Add(relatedEntry);
-                    }
-                }
-            }
-        }
-
-        return childEntries;
     }
 
     private static object ConvertGeometryToSerializableFormat(object value)
@@ -438,11 +399,20 @@ internal class AuditInterceptor : ISaveChangesInterceptor
         if (localPart.Length <= 2)
         {
             // If local part is too short, obscure it completely
-            return new string('*', localPart.Length) + domainPart.ToString();
+            return $"{new string('*', localPart.Length)}{domainPart}";
         }
 
         // Show first and last character, obscure the middle
         var obscuredLength = localPart.Length - 2;
         return $"{localPart[0]}{new string('*', obscuredLength)}{localPart[^1]}{domainPart}";
+    }
+
+    private static IDictionary<string, object> ObscureSensitiveAuditProperties(EntityEntry entry, IDictionary<string, object> properties)
+    {
+        if (entry.Entity is JobSubscriber && properties.TryGetValue(nameof(JobSubscriber.EmailAddress), out object? value))
+        {
+            properties[nameof(JobSubscriber.EmailAddress)] = ObscureEmailAddress(value?.ToString() ?? string.Empty);
+        }
+        return properties;
     }
 }

--- a/CSIDE.Data/Interceptors/AuditInterceptor.cs
+++ b/CSIDE.Data/Interceptors/AuditInterceptor.cs
@@ -266,9 +266,15 @@ internal class AuditInterceptor : ISaveChangesInterceptor
             secondaryId = primaryId;
             primaryId = ppoEvent.PPOApplicationId.ToString(CultureInfo.InvariantCulture);
         }
+        if(entry.Entity is JobSubscriber jobSubscriber)
+        {
+            secondaryId = ObscureEmailAddress(secondaryId);
+        }
 
         return (primaryId, secondaryId);
     }
+
+
 
     /// <summary>
     /// Default values for EntityId and SecondaryEntityId
@@ -410,5 +416,33 @@ internal class AuditInterceptor : ISaveChangesInterceptor
             return wktWriter.Write(geometry);
         }
         return value;
+    }
+
+    private static string ObscureEmailAddress(string emailAddress)
+    {
+        if (string.IsNullOrWhiteSpace(emailAddress))
+        {
+            return emailAddress;
+        }
+
+        var atIndex = emailAddress.IndexOf('@');
+        if (atIndex <= 0 || atIndex == emailAddress.Length - 1)
+        {
+            // Invalid email format, return as is
+            return emailAddress;
+        }
+
+        var localPart = emailAddress.AsSpan(0, atIndex);
+        var domainPart = emailAddress.AsSpan(atIndex);
+
+        if (localPart.Length <= 2)
+        {
+            // If local part is too short, obscure it completely
+            return new string('*', localPart.Length) + domainPart.ToString();
+        }
+
+        // Show first and last character, obscure the middle
+        var obscuredLength = localPart.Length - 2;
+        return $"{localPart[0]}{new string('*', obscuredLength)}{localPart[^1]}{domainPart}";
     }
 }

--- a/CSIDE.Web/Components/DMMO/DMMOApplicationList.razor
+++ b/CSIDE.Web/Components/DMMO/DMMOApplicationList.razor
@@ -19,7 +19,7 @@ AllowSorting="true"
 AllowSelection="false"
 AllowRowClick="true"
 OnRowClick="OnRowClick"
-AutoHidePaging="true"
+AutoHidePaging="false"
 Responsive="true">
 
     <GridColumns>

--- a/CSIDE.Web/Components/Infrastructure/InfrastructureItemsList.razor
+++ b/CSIDE.Web/Components/Infrastructure/InfrastructureItemsList.razor
@@ -17,7 +17,7 @@
         AllowSelection="false"
         AllowRowClick="true"
         OnRowClick="OnRowClick"
-        AutoHidePaging="true"
+        AutoHidePaging="false"
         Responsive="true">
 
     <GridColumns>

--- a/CSIDE.Web/Components/LandownerDeposits/LandownerDepositList.razor
+++ b/CSIDE.Web/Components/LandownerDeposits/LandownerDepositList.razor
@@ -20,7 +20,7 @@
       AllowSelection="false"
       AllowRowClick="true"
       OnRowClick="OnRowClick"
-      AutoHidePaging="true"
+      AutoHidePaging="false"
       Responsive="true">
 
     <GridColumns>

--- a/CSIDE.Web/Components/Maintenance/JobsList.razor
+++ b/CSIDE.Web/Components/Maintenance/JobsList.razor
@@ -19,7 +19,7 @@ AllowSorting="true"
 AllowSelection="false"
 AllowRowClick="true"
 OnRowClick="OnRowClick"
-AutoHidePaging="true"
+AutoHidePaging="false"
 Responsive="true">
 
     <GridColumns>

--- a/CSIDE.Web/Components/PPO/PPOApplicationList.razor
+++ b/CSIDE.Web/Components/PPO/PPOApplicationList.razor
@@ -19,7 +19,7 @@ AllowSorting="true"
 AllowSelection="false"
 AllowRowClick="true"
 OnRowClick="OnRowClick"
-AutoHidePaging="true"
+AutoHidePaging="false"
 Responsive="true">
 
     <GridColumns>

--- a/CSIDE.Web/Components/Pages/Management/UserEdit.razor
+++ b/CSIDE.Web/Components/Pages/Management/UserEdit.razor
@@ -32,14 +32,7 @@
                             <tr><th>@localizer["Name Label"]</th><td>@User.DisplayName</td></tr>
                             <tr>
                                 <th>@localizer["Email Label"]</th>
-                                <td>
-                                    @if(User.OtherMails is not null){
-                                        @foreach (var mail in User.OtherMails)
-                                        {
-                                            @mail
-                                            <br />
-                                        }
-                                    }
+                                <td>@(!string.IsNullOrEmpty(User.Mail) ?  User.Mail : (User.OtherMails is not null ? string.Join(',', User.OtherMails) : ""))
                                 </td>
                             </tr>
                         </tbody>

--- a/CSIDE.Web/Components/Pages/Management/Users.razor
+++ b/CSIDE.Web/Components/Pages/Management/Users.razor
@@ -45,10 +45,10 @@
                     <GridColumn TItem="Microsoft.Graph.Beta.Models.User" HeaderText="@localizer["User ID Label"]" PropertyName="Id" SortKeySelector="item => item.Id">
                         @context.Id
                     </GridColumn>
-                    <GridColumn TItem="Microsoft.Graph.Beta.Models.User" HeaderText="@localizer["Name Label"]" PropertyName="DisplayName" SortKeySelector="item => item.DisplayName">
+                    <GridColumn TItem="Microsoft.Graph.Beta.Models.User" IsDefaultSortColumn="true" HeaderText="@localizer["Name Label"]" PropertyName="DisplayName" SortKeySelector="item => item.DisplayName">
                         @context.DisplayName
                     </GridColumn>
-                    <GridColumn TItem="Microsoft.Graph.Beta.Models.User" Sortable="false" HeaderText="@localizer["Email Label"]" PropertyName="UserEmail">
+                    <GridColumn TItem="Microsoft.Graph.Beta.Models.User" Sortable="false" Filterable="false" HeaderText="@localizer["Email Label"]" PropertyName="UserEmail">
                         @(!string.IsNullOrEmpty(context.Mail) ?  context.Mail : (context.OtherMails is not null ? string.Join(',', context.OtherMails) : "") )
                     </GridColumn>
 
@@ -86,10 +86,10 @@
                     <GridColumn TItem="Microsoft.Graph.Beta.Models.User" HeaderText="@localizer["User ID Label"]" PropertyName="Id" SortKeySelector="item => item.Id">
                         @context.Id
                     </GridColumn>
-                    <GridColumn TItem="Microsoft.Graph.Beta.Models.User" HeaderText="@localizer["Name Label"]" PropertyName="DisplayName" SortKeySelector="item => item.DisplayName">
+                    <GridColumn TItem="Microsoft.Graph.Beta.Models.User" IsDefaultSortColumn="true" HeaderText="@localizer["Name Label"]" PropertyName="DisplayName" SortKeySelector="item => item.DisplayName">
                         @context.DisplayName
                     </GridColumn>
-                    <GridColumn TItem="Microsoft.Graph.Beta.Models.User" Sortable="false" HeaderText="@localizer["Email Label"]" PropertyName="UserEmail">
+                    <GridColumn TItem="Microsoft.Graph.Beta.Models.User" Sortable="false" Filterable="false" HeaderText="@localizer["Email Label"]" PropertyName="UserEmail">
                         @(!string.IsNullOrEmpty(context.Mail) ? context.Mail : (context.OtherMails is not null ? string.Join(',', context.OtherMails) : ""))
                     </GridColumn>
 

--- a/CSIDE.Web/Components/RightsOfWay/RoutesList.razor
+++ b/CSIDE.Web/Components/RightsOfWay/RoutesList.razor
@@ -17,7 +17,7 @@
         AllowSelection="false"
         AllowRowClick="true"
         OnRowClick="OnRowClick"
-        AutoHidePaging="true"
+        AutoHidePaging="false"
         Responsive="true">
 
     <GridColumns>

--- a/CSIDE.Web/Components/Shared/AuditLogModal.razor
+++ b/CSIDE.Web/Components/Shared/AuditLogModal.razor
@@ -92,6 +92,7 @@
 
     public async Task ShowAudit(Data.Models.Audit.AuditLog auditEntry)
     {
+        Changes = null;
         AuditLogEntry = auditEntry;
         if (auditEntry.OldValues is not null || auditEntry.NewValues is not null)
         {


### PR DESCRIPTION
This PR fixes a couple of minor bugs and annoyances.

- Makes sure the paging component is always shown on search results pages (where relevant), to allow users to always see the total number of items
- Make sure user email address is shown on user details page - Closes #41 
- Remove filtering from email address column for simplicity - Closes #37 
- Obscure email addresses for job subscribers in audit logs - Closes #42 
- Fix an issue where audit log entries would show the changes from a previously viewed entry if the audit log contained no changes - Closes #36 