### PR TITLE
Rangers can now edit media on RoWs

### DIFF
--- a/CSIDE.Web/Components/Pages/RightsOfWay/Details.razor
+++ b/CSIDE.Web/Components/Pages/RightsOfWay/Details.razor
@@ -168,7 +168,7 @@ else
                     <ChildContent>
                         <ErrorBoundary>
                             <ChildContent>
-                                <MediaList Route="@Route" IsEditable="UserCanEdit"></MediaList>
+                                <MediaList Route="@Route" IsEditable="UserCanEditMedia"></MediaList>
                             </ChildContent>
                             <ErrorContent Context="Exception">
                                 <GenericErrorAlert Exception="Exception"></GenericErrorAlert>
@@ -236,6 +236,7 @@ else
 
     private bool UserCanEdit { get; set; } = false;
     private bool UserCanEditStatements { get; set; } = false;
+    private bool UserCanEditMedia { get; set; } = false;
 
     private string[] AuditLogSectionNames => new string[] {
         nameof(Data.Models.RightsOfWay.Route),
@@ -271,6 +272,7 @@ else
             {
                 UserCanEdit = user.IsInRole("Administrator") || user.IsInRole("RoW Officer");
                 UserCanEditStatements = user.IsInRole("Administrator") || user.IsInRole("RoW Officer") || user.IsInRole("RoW Statement Editor");
+                UserCanEditMedia = user.IsInRole("Administrator") || user.IsInRole("RoW Officer") || user.IsInRole("Ranger");
             }
         }
     }

--- a/CSIDE.Web/Components/Pages/RightsOfWay/Details.razor
+++ b/CSIDE.Web/Components/Pages/RightsOfWay/Details.razor
@@ -234,7 +234,6 @@ else
     [CascadingParameter]
     private Task<AuthenticationState>? AuthenticationState { get; set; }
 
-    private bool UserCanEdit { get; set; } = false;
     private bool UserCanEditStatements { get; set; } = false;
     private bool UserCanEditMedia { get; set; } = false;
 
@@ -270,7 +269,6 @@ else
             var user = authState?.User;
             if (user is not null)
             {
-                UserCanEdit = user.IsInRole("Administrator") || user.IsInRole("RoW Officer");
                 UserCanEditStatements = user.IsInRole("Administrator") || user.IsInRole("RoW Officer") || user.IsInRole("RoW Statement Editor");
                 UserCanEditMedia = user.IsInRole("Administrator") || user.IsInRole("RoW Officer") || user.IsInRole("Ranger");
             }


### PR DESCRIPTION
This PR fixes a bug where rangers couldn't update media on Rights of Way. They could close routes but were not able to upload the closure notices to the route media.