### PR TITLE
Make sure correct user id is used in IsSurveyor policy

### DIFF
--- a/CSIDE.Web/Authorization/SurveyAuthorizationHandler.cs
+++ b/CSIDE.Web/Authorization/SurveyAuthorizationHandler.cs
@@ -1,5 +1,6 @@
 ﻿using CSIDE.Data.Models.Surveys;
 using Microsoft.AspNetCore.Authorization;
+using System.Security.Claims;
 
 namespace CSIDE.Authorization
 {
@@ -15,16 +16,16 @@ namespace CSIDE.Authorization
                 context.User.IsInRole("Surveyor")))
             {
                 context.Fail(new AuthorizationFailureReason(this, "User is not a surveyor"));
-                logger.LogInformation("User {userName} is not a surveyor", context.User.Identity?.Name);
+                logger.LogInformation("User {userName} is not a surveyor", context.User.DisplayName);
                 return Task.CompletedTask;
             }
-            var UserID = context.User.FindFirst(u => u.Type.Contains("nameidentifier", StringComparison.OrdinalIgnoreCase))?.Value;
+            var UserID = context.User.UserId;
             if (string.Equals(UserID, resource.SurveyorId, StringComparison.OrdinalIgnoreCase))
             {
                 context.Succeed(requirement);
                 return Task.CompletedTask;
             }
-            logger.LogInformation("User {userName} is not the surveyor for survey {surveyId}", context.User.Identity?.Name, resource.Id);
+            logger.LogInformation("User {userName} is not the surveyor for survey {surveyId}", context.User.DisplayName, resource.Id);
             context.Fail(new AuthorizationFailureReason(this, "User is not the surveyor for this survey"));
             return Task.CompletedTask;
         }


### PR DESCRIPTION
This PR fixes a bug where the wrong user ID is used in the IsSurveryor policy, resulting in users being incorrectly denied access to the bridge survey pages.