### PR TITLE
Fixed issues with jobs and infrastructure

### DIFF
--- a/CSIDE.Data/Interceptors/InfrastructureItemInterceptor.cs
+++ b/CSIDE.Data/Interceptors/InfrastructureItemInterceptor.cs
@@ -36,25 +36,33 @@ internal class InfrastructureItemInterceptor : ISaveChangesInterceptor
     {
         if (geom == null) return null;
 
-        return await context.Parishes
+        var parishId = await context.Parishes
             .AsNoTracking()
             .IgnoreAutoIncludes()
             .Where(p => p.Geom.Contains(geom))
             .Select(p => p.ParishId)
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
+
+        if (parishId == 0) return null;
+
+        return parishId;
     }
 
     private static async Task<int?> GetMaintenanceTeamIdForGeom(ApplicationDbContext context, Point? geom, CancellationToken cancellationToken)
     {
         if (geom == null) return null;
 
-        return await context.MaintenanceTeams
+        var maintenanceTeamId = await context.MaintenanceTeams
             .AsNoTracking()
             .IgnoreAutoIncludes()
             .Where(t => t.Geom.Contains(geom))
             .Select(t => t.Id)
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
+
+        if (maintenanceTeamId == 0) return null;
+
+        return maintenanceTeamId;
     }
 }

--- a/CSIDE.Data/Interceptors/MaintenanceJobInterceptor.cs
+++ b/CSIDE.Data/Interceptors/MaintenanceJobInterceptor.cs
@@ -40,13 +40,17 @@ internal class MaintenanceJobInterceptor : ISaveChangesInterceptor
     {
         if (geom == null) return null;
 
-        return await context.Parishes
+        var parishId = await context.Parishes
             .AsNoTracking()
             .IgnoreAutoIncludes()
             .Where(p => p.Geom.Contains(geom))
             .Select(p => p.ParishId)
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
+
+        if (parishId == 0) return null;
+
+        return parishId;
     }
 
     /// <summary>
@@ -56,12 +60,16 @@ internal class MaintenanceJobInterceptor : ISaveChangesInterceptor
     {
         if (geom == null) return null;
 
-        return await context.MaintenanceTeams
+        var maintenanceTeamId = await context.MaintenanceTeams
             .AsNoTracking()
             .IgnoreAutoIncludes()
             .Where(t => t.Geom.Contains(geom))
             .Select(t => t.Id)
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
+
+        if (maintenanceTeamId == 0) return null;
+
+        return maintenanceTeamId;
     }
 }


### PR DESCRIPTION
This PR fixes a bug where if a user tried to create or edit a maintenance job that fell slightly outside of a parish, the save would fail.

I have fixed this so now `null` values are passed back when a job is outside of a parish and also outside of a maintenance team area (which follow the parish outlines). 

The same issue was also happening when creating/editing infrastructure so I've applied the same fix there.

Closes #50