### PR TITLE
Add confirmed order published to DMMO order

### DIFF
--- a/CSIDE.API/CSIDE.API.csproj
+++ b/CSIDE.API/CSIDE.API.csproj
@@ -13,12 +13,12 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
     <PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="4.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.14.11" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSIDE.Data/CSIDE.Data.csproj
+++ b/CSIDE.Data/CSIDE.Data.csproj
@@ -10,20 +10,20 @@
     <PackageReference Include="Azure.AI.ContentSafety" Version="1.0.0" />
     <PackageReference Include="Azure.AI.TextAnalytics" Version="5.3.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="GovukNotify" Version="7.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.8" />
+    <PackageReference Include="GovukNotify" Version="8.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.9" />
     <PackageReference Include="Microsoft.Graph.Beta" Version="5.126.0-preview" />
     <PackageReference Include="NetTopologySuite" Version="2.6.0" />
     <PackageReference Include="NetTopologySuite.Features" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="10.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.1" />
+    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.4.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="10.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>
 

--- a/CSIDE.Data/Extensions/DMMOApplicationExtensions.cs
+++ b/CSIDE.Data/Extensions/DMMOApplicationExtensions.cs
@@ -56,7 +56,8 @@ public static class DMMOApplicationExtensions
                 DecisionOfSecState = o.DecisionOfSecState?.Name,
                 DateConfirmed = o.DateConfirmed?.ToDateOnly(),
                 DateSealed = o.DateSealed?.ToDateOnly(),
-                DatePublished = o.DatePublished?.ToDateOnly()
+                DatePublished = o.DatePublished?.ToDateOnly(),
+                ConfirmationPublishedDate = o.ConfirmationPublishedDate?.ToDateOnly(),
             })],
             CouncilDecisions = [.. application.DMMOCouncilDecisions.Select(cd => new CouncilDecisionPublicViewModel
             {

--- a/CSIDE.Data/Extensions/PPOApplicationExtensions.cs
+++ b/CSIDE.Data/Extensions/PPOApplicationExtensions.cs
@@ -54,6 +54,7 @@ namespace CSIDE.Data.Models.PPO
                     DateConfirmed = o.DateConfirmed?.ToDateOnly(),
                     DateSealed = o.DateSealed?.ToDateOnly(),
                     DatePublished = o.DatePublished?.ToDateOnly(),
+                    ConfirmationPublishedDate = o.ConfirmationPublishedDate?.ToDateOnly(),
                 })]
             };
         }

--- a/CSIDE.Data/Extensions/PPOApplicationExtensions.cs
+++ b/CSIDE.Data/Extensions/PPOApplicationExtensions.cs
@@ -53,7 +53,7 @@ namespace CSIDE.Data.Models.PPO
                     DecisionOfSecState = o.DecisionOfSecState?.Name,
                     DateConfirmed = o.DateConfirmed?.ToDateOnly(),
                     DateSealed = o.DateSealed?.ToDateOnly(),
-                    DatePublished = o.DatePublished?.ToDateOnly()
+                    DatePublished = o.DatePublished?.ToDateOnly(),
                 })]
             };
         }

--- a/CSIDE.Data/Migrations/20260622093310_AddConfirmedOredrPublishedToDMMOOrder.Designer.cs
+++ b/CSIDE.Data/Migrations/20260622093310_AddConfirmedOredrPublishedToDMMOOrder.Designer.cs
@@ -5,6 +5,7 @@ using CSIDE.Data;
 using CSIDE.Data.Models.Surveys;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using NodaTime;
@@ -15,9 +16,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CSIDE.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260622093310_AddConfirmedOredrPublishedToDMMOOrder")]
+    partial class AddConfirmedOredrPublishedToDMMOOrder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CSIDE.Data/Migrations/20260622093310_AddConfirmedOredrPublishedToDMMOOrder.cs
+++ b/CSIDE.Data/Migrations/20260622093310_AddConfirmedOredrPublishedToDMMOOrder.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+
+#nullable disable
+
+namespace CSIDE.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConfirmedOredrPublishedToDMMOOrder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<LocalDate>(
+                name: "confirmation_published_date",
+                schema: "cside",
+                table: "dmmo_orders",
+                type: "date",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "confirmation_published_date",
+                schema: "cside",
+                table: "dmmo_orders");
+        }
+    }
+}

--- a/CSIDE.Data/Migrations/20260622104536_AddConfirmedOrderPublishedToDMMOOrder.Designer.cs
+++ b/CSIDE.Data/Migrations/20260622104536_AddConfirmedOrderPublishedToDMMOOrder.Designer.cs
@@ -16,8 +16,8 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CSIDE.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20260622093310_AddConfirmedOredrPublishedToDMMOOrder")]
-    partial class AddConfirmedOredrPublishedToDMMOOrder
+    [Migration("20260622104536_AddConfirmedOrderPublishedToDMMOOrder")]
+    partial class AddConfirmedOrderPublishedToDMMOOrder
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/CSIDE.Data/Migrations/20260622104536_AddConfirmedOrderPublishedToDMMOOrder.cs
+++ b/CSIDE.Data/Migrations/20260622104536_AddConfirmedOrderPublishedToDMMOOrder.cs
@@ -6,7 +6,7 @@ using NodaTime;
 namespace CSIDE.Data.Migrations
 {
     /// <inheritdoc />
-    public partial class AddConfirmedOredrPublishedToDMMOOrder : Migration
+    public partial class AddConfirmedOrderPublishedToDMMOOrder : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/CSIDE.Data/Models/DMMO/DMMOOrder.cs
+++ b/CSIDE.Data/Models/DMMO/DMMOOrder.cs
@@ -18,6 +18,7 @@ namespace CSIDE.Data.Models.DMMO
         public LocalDate? DateConfirmed { get; set; }
         public LocalDate? DateSealed { get; set; }
         public LocalDate? DatePublished { get; set; }
+        public LocalDate? ConfirmationPublishedDate { get; set; }
         public bool? SubmitToPINS { get; set; }
     }
 }

--- a/CSIDE.Data/Models/Shared/OrderPublicViewModel.cs
+++ b/CSIDE.Data/Models/Shared/OrderPublicViewModel.cs
@@ -13,6 +13,7 @@
         public DateOnly? DateConfirmed { get; set; }
         public DateOnly? DateSealed { get; set; }
         public DateOnly? DatePublished { get; set; }
+        public DateOnly? ConfirmationPublishedDate { get; set; }
 
     }
 }

--- a/CSIDE.Shared/Properties/Resources.Designer.cs
+++ b/CSIDE.Shared/Properties/Resources.Designer.cs
@@ -1888,7 +1888,7 @@ namespace CSIDE.Shared.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Date confirmation published.
+        ///   Looks up a localized string similar to Date confirmed order published.
         /// </summary>
         public static string Date_Confirmation_Published_Label {
             get {

--- a/CSIDE.Shared/Properties/Resources.cy.resx
+++ b/CSIDE.Shared/Properties/Resources.cy.resx
@@ -1668,7 +1668,7 @@ Creu Blaendal Perchennog Tir newydd gan ddefnyddio map</value>
     <value>Ni ychwanegwyd unrhyw gyfeiriadau yr effeithiwyd arnynt</value>
   </data>
   <data name="Date Confirmation Published Label" xml:space="preserve">
-    <value>Dyddiad cyhoeddi cadarnhad</value>
+    <value>Dyddiad y cyhoeddwyd y gorchymyn cadarnhaol</value>
   </data>
   <data name="Comment Date Label" xml:space="preserve">
     <value>Dyddiad y sylw</value>

--- a/CSIDE.Shared/Properties/Resources.resx
+++ b/CSIDE.Shared/Properties/Resources.resx
@@ -1657,7 +1657,7 @@
     <value>No affected addresses have been added</value>
   </data>
   <data name="Date Confirmation Published Label" xml:space="preserve">
-    <value>Date confirmation published</value>
+    <value>Date confirmed order published</value>
   </data>
   <data name="Comment Date Label" xml:space="preserve">
     <value>Comment date</value>

--- a/CSIDE.Tests/CSIDE.Tests.csproj
+++ b/CSIDE.Tests/CSIDE.Tests.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.84">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.108">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">

--- a/CSIDE.Web/CSIDE.Web.csproj
+++ b/CSIDE.Web/CSIDE.Web.csproj
@@ -21,29 +21,29 @@
     <PackageReference Include="Blazor.Bootstrap" Version="3.5.0" />
     <PackageReference Include="Blazored.FluentValidation" Version="2.2.0" />
     <PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
-    <PackageReference Include="GovukNotify" Version="7.2.0" />
+    <PackageReference Include="GovukNotify" Version="8.1.0" />
     <PackageReference Include="Humanizer.Core" Version="3.0.10" />
-    <PackageReference Include="Markdig" Version="1.2.0" />
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.84">
+    <PackageReference Include="Markdig" Version="1.3.2" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.108">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
-    <PackageReference Include="Microsoft.Graph" Version="5.105.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.9.0" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Graph" Version="6.2.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.10.0" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.10.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="10.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.1" />
+    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.4.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="10.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.2" />
     <PackageReference Include="ProjNet" Version="2.1.0" />
   </ItemGroup>
 

--- a/CSIDE.Web/Components/DMMO/DMMOOrdersList.razor
+++ b/CSIDE.Web/Components/DMMO/DMMOOrdersList.razor
@@ -18,7 +18,7 @@
                             <strong>@(order.DMMOApplicationId)/@(order.OrderId)</strong>
                         </div>
                         <div class="card-body">
-                            @if (order.DateSealed.HasValue || order.DatePublished.HasValue || order.DateConfirmed.HasValue)
+                            @if (order.DateSealed.HasValue || order.DatePublished.HasValue || order.DateConfirmed.HasValue || order.ConfirmationPublishedDate.HasValue)
                             {
                                 <ul class="list-unstyled">
                                     @if (order.DateSealed.HasValue)
@@ -32,6 +32,10 @@
                                     @if (order.DateConfirmed.HasValue)
                                     {
                                         <li><strong>@localizer["Order Date Confirmed Label"]</strong>: @order.DateConfirmed</li>
+                                    }
+                                    @if (order.ConfirmationPublishedDate.HasValue)
+                                    {
+                                        <li><strong>@localizer["Date Confirmation Published Label"]</strong>: @order.ConfirmationPublishedDate</li>
                                     }
                                 </ul>
                             }
@@ -96,6 +100,10 @@
                             <tr>
                                 <th>@localizer["Order Confirmed Date Label"]</th>
                                 <td>@SelectedOrder.DateConfirmed</td>
+                            </tr>
+                            <tr>
+                                <th>@localizer["Date Confirmation Published Label"]</th>
+                                <td>@SelectedOrder.ConfirmationPublishedDate</td>
                             </tr>
                             <tr>
                                 <th>@localizer["Submit To PINS Label"]</th>

--- a/CSIDE.Web/Components/DMMO/OrderEditForm.razor
+++ b/CSIDE.Web/Components/DMMO/OrderEditForm.razor
@@ -109,8 +109,8 @@
         </div>
 
         <div class="mb-3 row">
-            <label class="form-label" for="confirmation-published-date">@localizer["Date Confirmation Published Label"]</label>
             <div class=" col-sm-4 col-md-6 col-lg-4">
+                <label class="form-label" for="confirmation-published-date">@localizer["Date Confirmation Published Label"]</label>
                 @{
                     string DateConfirmationPublishedStringRepresentation = "";
                     if (Order.ConfirmationPublishedDate.HasValue)

--- a/CSIDE.Web/Components/DMMO/OrderEditForm.razor
+++ b/CSIDE.Web/Components/DMMO/OrderEditForm.razor
@@ -108,6 +108,21 @@
             <ValidationMessage For="() => Order.DateConfirmed" />
         </div>
 
+        <div class="mb-3 row">
+            <label class="form-label" for="confirmation-published-date">@localizer["Date Confirmation Published Label"]</label>
+            <div class=" col-sm-4 col-md-6 col-lg-4">
+                @{
+                    string DateConfirmationPublishedStringRepresentation = "";
+                    if (Order.ConfirmationPublishedDate.HasValue)
+                    {
+                        DateConfirmationPublishedStringRepresentation = Order.ConfirmationPublishedDate.Value.ToDateOnly().ToString("yyyy-MM-dd");
+                    }
+                }
+                <input id="confirmation-published-date" type="date" class="form-control" value="@DateConfirmationPublishedStringRepresentation" @onchange="UpdateConfirmationPublishedDateProperty" />
+            </div>
+            <ValidationMessage For="() => Order.ConfirmationPublishedDate" />
+        </div>
+
         <YesNoBoolean @bind-Value="Order.SubmitToPINS" Label="@localizer["Submit To PINS Label"]" HasNullOption="true" NullValueLabel="@localizer["Unknown Label"]" class="my-3"></YesNoBoolean>
 
         @if (IsEdit)

--- a/CSIDE.Web/Components/DMMO/OrderEditForm.razor.cs
+++ b/CSIDE.Web/Components/DMMO/OrderEditForm.razor.cs
@@ -60,7 +60,10 @@ namespace CSIDE.Web.Components.DMMO
         {
             UpdateDateProperty(eventArgs, date => Order!.DateConfirmed = date);
         }
-
+        private void UpdateConfirmationPublishedDateProperty(ChangeEventArgs eventArgs)
+        {
+            UpdateDateProperty(eventArgs, date => Order!.ConfirmationPublishedDate = date);
+        }
         private void UpdateDateProperty(ChangeEventArgs eventArgs, Action<LocalDate?> updateProperty)
         {
             if (Order is not null && eventArgs.Value is not null)

--- a/CSIDE.Web/package-lock.json
+++ b/CSIDE.Web/package-lock.json
@@ -11,15 +11,15 @@
       "dependencies": {
         "ol": "10.9.0",
         "ol-ext": "4.0.38",
-        "proj4": "2.20.8"
+        "proj4": "2.20.9"
       },
       "devDependencies": {
         "@types/ol-ext": "npm:@siedlerchr/types-ol-ext@3.6.8",
-        "eslint": "10.3.0",
-        "ts-loader": "9.5.7",
+        "eslint": "10.5.0",
+        "ts-loader": "9.6.2",
         "typescript": "6.0.3",
-        "webpack": "5.106.2",
-        "webpack-cli": "7.0.2",
+        "webpack": "5.107.2",
+        "webpack-cli": "7.0.3",
         "webpack-merge": "6.0.1"
       }
     },
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -262,28 +262,6 @@
       "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
       "license": "MIT"
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -306,13 +284,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/ol-ext": {
@@ -523,9 +501,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -644,9 +622,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -667,19 +645,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -724,9 +689,9 @@
       "license": "MIT"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -860,16 +825,16 @@
       "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.355",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
-      "integrity": "sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==",
+      "version": "1.5.376",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
-      "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -934,18 +899,21 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -1133,20 +1101,10 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.9.1"
-      }
-    },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -1160,19 +1118,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -1290,9 +1235,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1389,16 +1334,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-object": {
@@ -1566,20 +1501,6 @@
       "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
       "license": "MIT"
     },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -1628,11 +1549,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.44",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
-      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/numcodecs": {
       "version": "0.3.2",
@@ -1789,13 +1713,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -1881,9 +1805,9 @@
       }
     },
     "node_modules/proj4": {
-      "version": "2.20.8",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.8.tgz",
-      "integrity": "sha512-1C8sfT4xY4PAPwk0MroFBTGF4R4bzDXdmPQTGYVLsoNssrZ9odzObxS2dTeGBty8jW8KO7h16C1Hs2JP+ctfFw==",
+      "version": "2.20.9",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.9.tgz",
+      "integrity": "sha512-GLBGqXaTcdWnppre3o1sMmy4DcMGSGq/ng+9k2MTNddarRK6SveINqlqYzi3xEXuy06ljY1TTrC6H9C4f360IQ==",
       "license": "MIT",
       "dependencies": {
         "mgrs": "1.0.0",
@@ -1891,6 +1815,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ahocevar"
+      },
+      "peerDependencies": {
+        "geotiff": "*"
+      },
+      "peerDependenciesMeta": {
+        "geotiff": {
+          "optional": true
+        }
       }
     },
     "node_modules/protocol-buffers-schema": {
@@ -2076,19 +2008,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
@@ -2197,9 +2116,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
-      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2216,9 +2135,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz",
-      "integrity": "sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2276,38 +2195,29 @@
         }
       }
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/ts-loader": {
-      "version": "9.5.7",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.7.tgz",
-      "integrity": "sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==",
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.6.2.tgz",
+      "integrity": "sha512-R4iuczmtgxvtuI556s+hTZ6/7Ee03VCAk/l/M8LY1OAsUgB7YydsCxkgq9D9pKRaD7GJqUi2u8fp9zZP/ufjKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
-        "enhanced-resolve": "^5.0.0",
-        "micromatch": "^4.0.0",
-        "semver": "^7.3.4",
+        "picomatch": "^4.0.0",
         "source-map": "^0.7.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "peerDependencies": {
+        "loader-utils": "*",
         "typescript": "*",
-        "webpack": "^5.0.0"
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "loader-utils": {
+          "optional": true
+        }
       }
     },
     "node_modules/type-check": {
@@ -2338,9 +2248,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2395,13 +2305,12 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "engines": {
@@ -2415,13 +2324,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/webpack": {
-      "version": "5.106.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
-      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+      "version": "5.107.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
+      "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
@@ -2431,20 +2339,20 @@
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.20.0",
-        "es-module-lexer": "^2.0.0",
+        "enhanced-resolve": "^5.22.0",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "loader-runner": "^4.3.1",
+        "loader-runner": "^4.3.2",
         "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.17",
+        "terser-webpack-plugin": "^5.5.0",
         "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.4"
+        "webpack-sources": "^3.5.0"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -2463,17 +2371,16 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.0.2.tgz",
-      "integrity": "sha512-dB0R4T+C/8YuvM+fabdvil6QE44/ChDXikV5lOOkrUeCkW5hTJv2pGLE3keh+D5hjYw8icBaJkZzpFoaHV4T+g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.0.3.tgz",
+      "integrity": "sha512-2E2C6A1e2El7791zQgTH7LPIuwLjRliow9OHS/qlJc9pwhZlCoL/uiwqd/1WSlXT83wJfmfDbkcqHXuXoPJZ3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "^1.0.0",
+        "@discoveryjs/json-ext": "^1.1.0",
         "commander": "^14.0.3",
         "cross-spawn": "^7.0.6",
         "envinfo": "^7.14.0",
-        "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
         "interpret": "^3.1.1",
         "rechoir": "^0.8.0",
@@ -2529,9 +2436,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
-      "integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/CSIDE.Web/package.json
+++ b/CSIDE.Web/package.json
@@ -18,15 +18,15 @@
   "dependencies": {
     "ol": "10.9.0",
     "ol-ext": "4.0.38",
-    "proj4": "2.20.8"
+    "proj4": "2.20.9"
   },
   "devDependencies": {
     "@types/ol-ext": "npm:@siedlerchr/types-ol-ext@3.6.8",
-    "eslint": "10.3.0",
-    "ts-loader": "9.5.7",
+    "eslint": "10.5.0",
+    "ts-loader": "9.6.2",
     "typescript": "6.0.3",
-    "webpack": "5.106.2",
-    "webpack-cli": "7.0.2",
+    "webpack": "5.107.2",
+    "webpack-cli": "7.0.3",
     "webpack-merge": "6.0.1"
   },
   "-vs-binding": {


### PR DESCRIPTION
Adds the missing Confirmed Order Published date to DMMO orders. This data was already in PPO orders, but not included in DMMOs. 

Also updates npm and NuGet packages to their latest.

Closes #55 