### PR TITLE
Fixed survey card colour when in dark mode

### DIFF
--- a/CSIDE.Web/Components/Infrastructure/InfrastructureSurveyList.razor
+++ b/CSIDE.Web/Components/Infrastructure/InfrastructureSurveyList.razor
@@ -19,7 +19,7 @@ else
             {
                 string url = $"surveys/bridge/{survey.Id}/details";
                 <div class="col-lg-6">
-                    <Card Color="CardColor.Light">
+                    <Card class="card bg-light-subtle h-100">
                         <CardBody>
                             <CardTitle>@localizer["Bridge Survey Details Title",$"{IDPrefixOptions.Value.Infrastructure}{survey.InfrastructureItemId}/{survey.Id}"]</CardTitle>
                             <CardText>


### PR DESCRIPTION
This PR fixes a bug where the survey card wasn't changing colours when switching to dark mode.

Closes #60