### PR TITLE
Allow API to search by postcode and fix location search issue

### DIFF
--- a/CSIDE.API/CSIDE.API.csproj
+++ b/CSIDE.API/CSIDE.API.csproj
@@ -16,9 +16,10 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.10.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="4.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.16.4" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSIDE.Data/CSIDE.Data.csproj
+++ b/CSIDE.Data/CSIDE.Data.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Azure.AI.ContentSafety" Version="1.0.0" />
     <PackageReference Include="Azure.AI.TextAnalytics" Version="5.3.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="GovukNotify" Version="8.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />

--- a/CSIDE.Data/Helpers/PlaceGeometryHelper.cs
+++ b/CSIDE.Data/Helpers/PlaceGeometryHelper.cs
@@ -1,0 +1,36 @@
+﻿using CSIDE.Data.Models.Shared;
+using NetTopologySuite.Geometries;
+
+namespace CSIDE.Data.Helpers
+{
+    public static class PlaceGeometryHelper
+    {
+        public static Polygon CreateBBOXPolygonFromPlaceGeometry(GazetteerEntry place)
+        {
+            if (place.LocalType == "Postcode" || (place.MbrXMin == 0 && place.MbrXMax == 0 && place.MbrYMin == 0 && place.MbrYMax == 0))
+            {
+                //postcodes don't come with MBRs, so approximate by putting a 500m radius round the point. Not perfect but acceptable
+                //For safety, also do this if the MBRs are returned as 0 (in case local type name changes for example)
+                place.MbrXMin = place.GeometryX - 500;
+                place.MbrXMax = place.GeometryX + 500;
+                place.MbrYMin = place.GeometryY - 500;
+                place.MbrYMax = place.GeometryY + 500;
+            }
+            var bboxPolygon = new Polygon(
+                new LinearRing(
+                    [
+                        new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMin)),
+                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMax)),
+                                new(decimal.ToDouble(place.MbrXMax), decimal.ToDouble(place.MbrYMax)),
+                                new(decimal.ToDouble(place.MbrXMax), decimal.ToDouble(place.MbrYMin)),
+                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMin)),
+                    ]
+                )
+            )
+            {
+                SRID = 27700,
+            };
+            return bboxPolygon;
+        }
+    }
+}

--- a/CSIDE.Data/Services/DMMOService.cs
+++ b/CSIDE.Data/Services/DMMOService.cs
@@ -1,4 +1,5 @@
-﻿using CSIDE.Data.Models.DMMO;
+﻿using CSIDE.Data.Helpers;
+using CSIDE.Data.Models.DMMO;
 using CSIDE.Data.Models.Shared;
 using CSIDE.Shared.Options;
 using Microsoft.EntityFrameworkCore;
@@ -134,7 +135,7 @@ public class DMMOService(IDbContextFactory<ApplicationDbContext> contextFactory,
             var place = await placesSearchService.GetPlaceByName(Location);
             if (place is not null)
             {
-                Polygon bboxPolygon = PlacesSearchService.CreateBBOXPolygonFromPlaceGeometry(place);
+                Polygon bboxPolygon = PlaceGeometryHelper.CreateBBOXPolygonFromPlaceGeometry(place);
                 query = query.Where(d => d.Geom.Intersects(bboxPolygon));
             }
             else

--- a/CSIDE.Data/Services/DMMOService.cs
+++ b/CSIDE.Data/Services/DMMOService.cs
@@ -134,20 +134,7 @@ public class DMMOService(IDbContextFactory<ApplicationDbContext> contextFactory,
             var place = await placesSearchService.GetPlaceByName(Location);
             if (place is not null)
             {
-                var bboxPolygon = new Polygon(
-                    new LinearRing(
-                        [
-                            new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMin)),
-                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMax)),
-                                new(decimal.ToDouble(place.MbrXMax), decimal.ToDouble(place.MbrYMax)),
-                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMax)),
-                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMin)),
-                        ]
-                    )
-                )
-                {
-                    SRID = 27700,
-                };
+                Polygon bboxPolygon = PlacesSearchService.CreateBBOXPolygonFromPlaceGeometry(place);
                 query = query.Where(d => d.Geom.Intersects(bboxPolygon));
             }
         }

--- a/CSIDE.Data/Services/DMMOService.cs
+++ b/CSIDE.Data/Services/DMMOService.cs
@@ -129,13 +129,17 @@ public class DMMOService(IDbContextFactory<ApplicationDbContext> contextFactory,
         {
             query = query.Where(d => d.DMMOClaimedStatuses.Any(c => c.ClaimedStatusId == parsedApplicationClaimedStatusId));
         }
-        if (Location is not null)
+        if (!string.IsNullOrWhiteSpace(Location))
         {
             var place = await placesSearchService.GetPlaceByName(Location);
             if (place is not null)
             {
                 Polygon bboxPolygon = PlacesSearchService.CreateBBOXPolygonFromPlaceGeometry(place);
                 query = query.Where(d => d.Geom.Intersects(bboxPolygon));
+            }
+            else
+            {
+                query = query.Where(d => false);
             }
         }
 

--- a/CSIDE.Data/Services/IPlacesSearchService.cs
+++ b/CSIDE.Data/Services/IPlacesSearchService.cs
@@ -1,4 +1,5 @@
 ﻿using CSIDE.Data.Models.Shared;
+using NetTopologySuite.Geometries;
 
 namespace CSIDE.Data.Services
 {

--- a/CSIDE.Data/Services/IPlacesSearchService.cs
+++ b/CSIDE.Data/Services/IPlacesSearchService.cs
@@ -1,5 +1,4 @@
 ﻿using CSIDE.Data.Models.Shared;
-using NetTopologySuite.Geometries;
 
 namespace CSIDE.Data.Services
 {

--- a/CSIDE.Data/Services/LandownerDepositService.cs
+++ b/CSIDE.Data/Services/LandownerDepositService.cs
@@ -123,15 +123,18 @@ public class LandownerDepositService(IDbContextFactory<ApplicationDbContext> con
 
         if (!string.IsNullOrWhiteSpace(Location))
         {
-            var place = await placesSearchService.GetPlaceByName(Location);
+            var locationSearch = Location.Trim();
+
+            // location could mean an actual on the ground location OR part of the location string.
+            var place = await placesSearchService.GetPlaceByName(locationSearch);
             if (place is not null)
             {
                 Polygon bboxPolygon = PlaceGeometryHelper.CreateBBOXPolygonFromPlaceGeometry(place);
-                query = query.Where(d => d.Geom.Intersects(bboxPolygon));
+                query = query.Where(d => d.Geom.Intersects(bboxPolygon) || EF.Functions.ILike(d.Location!, $"%{locationSearch}%"));
             }
             else
             {
-                query = query.Where(d => false);
+                query = query.Where(d => EF.Functions.ILike(d.Location!, $"%{locationSearch}%"));
             }
         }
 

--- a/CSIDE.Data/Services/LandownerDepositService.cs
+++ b/CSIDE.Data/Services/LandownerDepositService.cs
@@ -122,23 +122,11 @@ public class LandownerDepositService(IDbContextFactory<ApplicationDbContext> con
 
         if (Location is not null)
         {
+            
             var place = await placesSearchService.GetPlaceByName(Location);
             if (place is not null)
             {
-                var bboxPolygon = new Polygon(
-                    new LinearRing(
-                        [
-                            new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMin)),
-                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMax)),
-                                new(decimal.ToDouble(place.MbrXMax), decimal.ToDouble(place.MbrYMax)),
-                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMax)),
-                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMin)),
-                        ]
-                    )
-                )
-                {
-                    SRID = 27700,
-                };
+                Polygon bboxPolygon = PlacesSearchService.CreateBBOXPolygonFromPlaceGeometry(place);
                 query = query.Where(l => l.Geom.Intersects(bboxPolygon));
             }
         }

--- a/CSIDE.Data/Services/LandownerDepositService.cs
+++ b/CSIDE.Data/Services/LandownerDepositService.cs
@@ -120,14 +120,17 @@ public class LandownerDepositService(IDbContextFactory<ApplicationDbContext> con
             query = query.Where(d => d.LandownerDepositParishes.Any(p => p.ParishId == parsedParishId));
         }
 
-        if (Location is not null)
+        if (!string.IsNullOrWhiteSpace(Location))
         {
-            
             var place = await placesSearchService.GetPlaceByName(Location);
             if (place is not null)
             {
                 Polygon bboxPolygon = PlacesSearchService.CreateBBOXPolygonFromPlaceGeometry(place);
-                query = query.Where(l => l.Geom.Intersects(bboxPolygon));
+                query = query.Where(d => d.Geom.Intersects(bboxPolygon));
+            }
+            else
+            {
+                query = query.Where(d => false);
             }
         }
 

--- a/CSIDE.Data/Services/LandownerDepositService.cs
+++ b/CSIDE.Data/Services/LandownerDepositService.cs
@@ -1,4 +1,5 @@
-﻿using CSIDE.Data.Models.LandownerDeposits;
+﻿using CSIDE.Data.Helpers;
+using CSIDE.Data.Models.LandownerDeposits;
 using CSIDE.Data.Models.Shared;
 using CSIDE.Shared.Options;
 using Microsoft.EntityFrameworkCore;
@@ -125,7 +126,7 @@ public class LandownerDepositService(IDbContextFactory<ApplicationDbContext> con
             var place = await placesSearchService.GetPlaceByName(Location);
             if (place is not null)
             {
-                Polygon bboxPolygon = PlacesSearchService.CreateBBOXPolygonFromPlaceGeometry(place);
+                Polygon bboxPolygon = PlaceGeometryHelper.CreateBBOXPolygonFromPlaceGeometry(place);
                 query = query.Where(d => d.Geom.Intersects(bboxPolygon));
             }
             else

--- a/CSIDE.Data/Services/PPOService.cs
+++ b/CSIDE.Data/Services/PPOService.cs
@@ -1,4 +1,5 @@
-﻿using CSIDE.Data.Models.PPO;
+﻿using CSIDE.Data.Helpers;
+using CSIDE.Data.Models.PPO;
 using CSIDE.Data.Models.Shared;
 using CSIDE.Shared.Options;
 using Microsoft.EntityFrameworkCore;
@@ -158,7 +159,7 @@ namespace CSIDE.Data.Services
                 var place = await placesSearchService.GetPlaceByName(Location);
                 if (place is not null)
                 {
-                    Polygon bboxPolygon = PlacesSearchService.CreateBBOXPolygonFromPlaceGeometry(place);
+                    Polygon bboxPolygon = PlaceGeometryHelper.CreateBBOXPolygonFromPlaceGeometry(place);
                     query = query.Where(d => d.Geom.Intersects(bboxPolygon));
                 }
                 else

--- a/CSIDE.Data/Services/PPOService.cs
+++ b/CSIDE.Data/Services/PPOService.cs
@@ -158,20 +158,7 @@ namespace CSIDE.Data.Services
                 var place = await placesSearchService.GetPlaceByName(Location);
                 if (place is not null)
                 {
-                    var bboxPolygon = new Polygon(
-                        new LinearRing(
-                            [
-                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMin)),
-                                    new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMax)),
-                                    new(decimal.ToDouble(place.MbrXMax), decimal.ToDouble(place.MbrYMax)),
-                                    new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMax)),
-                                    new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMin)),
-                            ]
-                        )
-                    )
-                    {
-                        SRID = 27700,
-                    };
+                    Polygon bboxPolygon = PlacesSearchService.CreateBBOXPolygonFromPlaceGeometry(place);
                     query = query.Where(d => d.Geom.Intersects(bboxPolygon));
                 }
             }

--- a/CSIDE.Data/Services/PPOService.cs
+++ b/CSIDE.Data/Services/PPOService.cs
@@ -153,13 +153,17 @@ namespace CSIDE.Data.Services
             {
                 query = query.Where(d => d.IsPublic == IsPublic);
             }
-            if (Location is not null)
+            if (!string.IsNullOrWhiteSpace(Location))
             {
                 var place = await placesSearchService.GetPlaceByName(Location);
                 if (place is not null)
                 {
                     Polygon bboxPolygon = PlacesSearchService.CreateBBOXPolygonFromPlaceGeometry(place);
                     query = query.Where(d => d.Geom.Intersects(bboxPolygon));
+                }
+                else
+                {
+                    query = query.Where(d => false);
                 }
             }
 

--- a/CSIDE.Data/Services/PlacesSearchService.cs
+++ b/CSIDE.Data/Services/PlacesSearchService.cs
@@ -1,13 +1,14 @@
 ﻿using CSIDE.Data.Models.Shared;
 using CSIDE.Shared.Options;
 using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
 namespace CSIDE.Data.Services;
 
-public class PlacesSearchService(IHttpClientFactory httpClientFactory, IOptions<MappingOptions> MappingOptions) : IPlacesSearchService
+public partial class PlacesSearchService(IHttpClientFactory httpClientFactory, IOptions<MappingOptions> MappingOptions) : IPlacesSearchService
 {
     private readonly string apiKey = MappingOptions.Value.OSMapsAPIKey;
 
@@ -74,7 +75,7 @@ public class PlacesSearchService(IHttpClientFactory httpClientFactory, IOptions<
             return AddressSearchType.UPRN;
         }
 
-        if (Regex.IsMatch(searchInput, "^(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))$"))
+        if (PostcodeRegex().IsMatch(searchInput))
         {
             return AddressSearchType.Postcode;
         }
@@ -89,7 +90,7 @@ public class PlacesSearchService(IHttpClientFactory httpClientFactory, IOptions<
         var baseAddress = "https://api.os.uk/search/names/v1/find";
 
         var url = baseAddress;
-        string typeFilters = "&fq=LOCAL_TYPE:City LOCAL_TYPE:Hamlet LOCAL_TYPE:Other_Settlement LOCAL_TYPE:Town LOCAL_TYPE:Village";
+        string typeFilters = "&fq=LOCAL_TYPE:City LOCAL_TYPE:Hamlet LOCAL_TYPE:Other_Settlement LOCAL_TYPE:Town LOCAL_TYPE:Village LOCAL_TYPE:Postcode";
         string bboxFilter = $"&fq=BBOX:{MappingOptions.Value.StartBounds.MinX},{MappingOptions.Value.StartBounds.MinY},{MappingOptions.Value.StartBounds.MaxX},{MappingOptions.Value.StartBounds.MaxY}";
         url += $"?query={searchInput}&maxResults=1{typeFilters}{bboxFilter}";
 
@@ -104,8 +105,38 @@ public class PlacesSearchService(IHttpClientFactory httpClientFactory, IOptions<
         }
         return null;
     }
-
+    public static Polygon CreateBBOXPolygonFromPlaceGeometry(GazetteerEntry place)
+    {
+        if (place.LocalType == "Postcode" || (place.MbrXMin == 0 && place.MbrXMax == 0 && place.MbrYMin == 0 && place.MbrYMax == 0))
+        {
+            //postcodes don't come with MBRs, so apporximate by putting a 500m radius round the point. Not perfect but acceptable
+            //For safety, also do this if the MBRs are returned as 0 (in case localtype name changes for example)
+            place.MbrXMin = place.GeometryX - 500;
+            place.MbrXMax = place.GeometryX + 500;
+            place.MbrYMin = place.GeometryY - 500;
+            place.MbrYMax = place.GeometryY + 500;
+        }
+        var bboxPolygon = new Polygon(
+            new LinearRing(
+                [
+                    new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMin)),
+                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMax)),
+                                new(decimal.ToDouble(place.MbrXMax), decimal.ToDouble(place.MbrYMax)),
+                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMax)),
+                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMin)),
+                ]
+            )
+        )
+        {
+            SRID = 27700,
+        };
+        return bboxPolygon;
+    }
+    [GeneratedRegex("^(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))$")]
+    private static partial Regex PostcodeRegex();
 }
+
+
 
 enum AddressSearchType
 {

--- a/CSIDE.Data/Services/PlacesSearchService.cs
+++ b/CSIDE.Data/Services/PlacesSearchService.cs
@@ -105,33 +105,7 @@ public partial class PlacesSearchService(IHttpClientFactory httpClientFactory, I
         }
         return null;
     }
-    public static Polygon CreateBBOXPolygonFromPlaceGeometry(GazetteerEntry place)
-    {
-        if (place.LocalType == "Postcode" || (place.MbrXMin == 0 && place.MbrXMax == 0 && place.MbrYMin == 0 && place.MbrYMax == 0))
-        {
-            //postcodes don't come with MBRs, so apporximate by putting a 500m radius round the point. Not perfect but acceptable
-            //For safety, also do this if the MBRs are returned as 0 (in case localtype name changes for example)
-            place.MbrXMin = place.GeometryX - 500;
-            place.MbrXMax = place.GeometryX + 500;
-            place.MbrYMin = place.GeometryY - 500;
-            place.MbrYMax = place.GeometryY + 500;
-        }
-        var bboxPolygon = new Polygon(
-            new LinearRing(
-                [
-                    new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMin)),
-                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMax)),
-                                new(decimal.ToDouble(place.MbrXMax), decimal.ToDouble(place.MbrYMax)),
-                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMax)),
-                                new(decimal.ToDouble(place.MbrXMin), decimal.ToDouble(place.MbrYMin)),
-                ]
-            )
-        )
-        {
-            SRID = 27700,
-        };
-        return bboxPolygon;
-    }
+
     [GeneratedRegex("^(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))$")]
     private static partial Regex PostcodeRegex();
 }

--- a/CSIDE.Tests/CSIDE.Tests.csproj
+++ b/CSIDE.Tests/CSIDE.Tests.csproj
@@ -12,11 +12,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.108">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.122">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">

--- a/CSIDE.Tests/Helpers/PlaceGeometryHelperTests.cs
+++ b/CSIDE.Tests/Helpers/PlaceGeometryHelperTests.cs
@@ -1,0 +1,287 @@
+﻿using CSIDE.Data.Helpers;
+using CSIDE.Data.Models.Shared;
+using NetTopologySuite.Geometries;
+using Xunit;
+
+namespace CSIDE.Tests;
+
+public class PlaceGeometryHelperTests
+{
+    [Fact]
+    public void CreateBBOXPolygonFromPlaceGeometry_PostcodeLocalType_CalculatesMBRWithRadius()
+    {
+        // Arrange
+        var place = new GazetteerEntry
+        {
+            LocalType = "Postcode",
+            GeometryX = 1000m,
+            GeometryY = 2000m,
+            MbrXMin = 100m,
+            MbrXMax = 200m,
+            MbrYMin = 300m,
+            MbrYMax = 400m
+        };
+
+        // Act
+        var result = PlaceGeometryHelper.CreateBBOXPolygonFromPlaceGeometry(place);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(27700, result.SRID);
+        Assert.Equal(5, result.Coordinates.Length); // Polygon should have 5 coordinates (closed ring)
+        
+        // Verify the coordinates are based on calculated MBR (GeometryX/Y ± 500)
+        Assert.Equal(500.0, result.Coordinates[0].X); // MbrXMin = 1000 - 500
+        Assert.Equal(1500.0, result.Coordinates[0].Y); // MbrYMin = 2000 - 500
+        Assert.Equal(500.0, result.Coordinates[1].X); // MbrXMin
+        Assert.Equal(2500.0, result.Coordinates[1].Y); // MbrYMax = 2000 + 500
+        Assert.Equal(1500.0, result.Coordinates[2].X); // MbrXMax = 1000 + 500
+        Assert.Equal(2500.0, result.Coordinates[2].Y); // MbrYMax
+        Assert.Equal(1500.0, result.Coordinates[3].X); // MbrXMax
+        Assert.Equal(1500.0, result.Coordinates[3].Y); // MbrYMin
+        Assert.Equal(500.0, result.Coordinates[4].X); // MbrXMin (closing coordinate)
+        Assert.Equal(1500.0, result.Coordinates[4].Y); // MbrYMin (closing coordinate)
+    }
+
+    [Fact]
+    public void CreateBBOXPolygonFromPlaceGeometry_AllMBRValuesZero_CalculatesMBRWithRadius()
+    {
+        // Arrange
+        var place = new GazetteerEntry
+        {
+            LocalType = "City",
+            GeometryX = 500m,
+            GeometryY = 750m,
+            MbrXMin = 0m,
+            MbrXMax = 0m,
+            MbrYMin = 0m,
+            MbrYMax = 0m
+        };
+
+        // Act
+        var result = PlaceGeometryHelper.CreateBBOXPolygonFromPlaceGeometry(place);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(27700, result.SRID);
+        Assert.Equal(5, result.Coordinates.Length);
+        
+        // Verify the coordinates are based on calculated MBR (GeometryX/Y ± 500)
+        Assert.Equal(0.0, result.Coordinates[0].X); // MbrXMin = 500 - 500
+        Assert.Equal(250.0, result.Coordinates[0].Y); // MbrYMin = 750 - 500
+        Assert.Equal(0.0, result.Coordinates[1].X); // MbrXMin
+        Assert.Equal(1250.0, result.Coordinates[1].Y); // MbrYMax = 750 + 500
+        Assert.Equal(1000.0, result.Coordinates[2].X); // MbrXMax = 500 + 500
+        Assert.Equal(1250.0, result.Coordinates[2].Y); // MbrYMax
+        Assert.Equal(1000.0, result.Coordinates[3].X); // MbrXMax
+        Assert.Equal(250.0, result.Coordinates[3].Y); // MbrYMin
+        Assert.Equal(0.0, result.Coordinates[4].X); // MbrXMin (closing coordinate)
+        Assert.Equal(250.0, result.Coordinates[4].Y); // MbrYMin (closing coordinate)
+    }
+
+    [Fact]
+    public void CreateBBOXPolygonFromPlaceGeometry_NonPostcodeWithValidMBR_UsesProvidedMBRValues()
+    {
+        // Arrange
+        var place = new GazetteerEntry
+        {
+            LocalType = "City",
+            GeometryX = 1000m,
+            GeometryY = 2000m,
+            MbrXMin = 100m,
+            MbrXMax = 200m,
+            MbrYMin = 300m,
+            MbrYMax = 400m
+        };
+
+        // Act
+        var result = PlaceGeometryHelper.CreateBBOXPolygonFromPlaceGeometry(place);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(27700, result.SRID);
+        Assert.Equal(5, result.Coordinates.Length);
+        
+        // Verify the coordinates use the provided MBR values
+        Assert.Equal(100.0, result.Coordinates[0].X); // MbrXMin
+        Assert.Equal(300.0, result.Coordinates[0].Y); // MbrYMin
+        Assert.Equal(100.0, result.Coordinates[1].X); // MbrXMin
+        Assert.Equal(400.0, result.Coordinates[1].Y); // MbrYMax
+        Assert.Equal(200.0, result.Coordinates[2].X); // MbrXMax
+        Assert.Equal(400.0, result.Coordinates[2].Y); // MbrYMax
+        Assert.Equal(200.0, result.Coordinates[3].X); // MbrXMax
+        Assert.Equal(300.0, result.Coordinates[3].Y); // MbrYMin
+        Assert.Equal(100.0, result.Coordinates[4].X); // MbrXMin (closing coordinate)
+        Assert.Equal(300.0, result.Coordinates[4].Y); // MbrYMin (closing coordinate)
+    }
+
+    [Fact]
+    public void CreateBBOXPolygonFromPlaceGeometry_PartialMBRZeros_UsesProvidedMBRValues()
+    {
+        // Arrange - Only some MBR values are zero, but not all
+        var place = new GazetteerEntry
+        {
+            LocalType = "Town",
+            GeometryX = 5000m,
+            GeometryY = 6000m,
+            MbrXMin = 0m,
+            MbrXMax = 1000m,
+            MbrYMin = 500m,
+            MbrYMax = 0m
+        };
+
+        // Act
+        var result = PlaceGeometryHelper.CreateBBOXPolygonFromPlaceGeometry(place);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(27700, result.SRID);
+        Assert.Equal(5, result.Coordinates.Length);
+        
+        // Verify the coordinates use the provided MBR values (not calculated)
+        Assert.Equal(0.0, result.Coordinates[0].X); // MbrXMin
+        Assert.Equal(500.0, result.Coordinates[0].Y); // MbrYMin
+        Assert.Equal(0.0, result.Coordinates[1].X); // MbrXMin
+        Assert.Equal(0.0, result.Coordinates[1].Y); // MbrYMax
+        Assert.Equal(1000.0, result.Coordinates[2].X); // MbrXMax
+        Assert.Equal(0.0, result.Coordinates[2].Y); // MbrYMax
+        Assert.Equal(1000.0, result.Coordinates[3].X); // MbrXMax
+        Assert.Equal(500.0, result.Coordinates[3].Y); // MbrYMin
+        Assert.Equal(0.0, result.Coordinates[4].X); // MbrXMin (closing coordinate)
+        Assert.Equal(500.0, result.Coordinates[4].Y); // MbrYMin (closing coordinate)
+    }
+
+    [Fact]
+    public void CreateBBOXPolygonFromPlaceGeometry_NegativeGeometryCoordinates_CalculatesMBRCorrectly()
+    {
+        // Arrange
+        var place = new GazetteerEntry
+        {
+            LocalType = "Postcode",
+            GeometryX = -1000m,
+            GeometryY = -2000m,
+            MbrXMin = 0m,
+            MbrXMax = 0m,
+            MbrYMin = 0m,
+            MbrYMax = 0m
+        };
+
+        // Act
+        var result = PlaceGeometryHelper.CreateBBOXPolygonFromPlaceGeometry(place);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(27700, result.SRID);
+        Assert.Equal(5, result.Coordinates.Length);
+        
+        // Verify the coordinates are based on calculated MBR (negative GeometryX/Y ± 500)
+        Assert.Equal(-1500.0, result.Coordinates[0].X); // MbrXMin = -1000 - 500
+        Assert.Equal(-2500.0, result.Coordinates[0].Y); // MbrYMin = -2000 - 500
+        Assert.Equal(-1500.0, result.Coordinates[1].X); // MbrXMin
+        Assert.Equal(-1500.0, result.Coordinates[1].Y); // MbrYMax = -2000 + 500
+        Assert.Equal(-500.0, result.Coordinates[2].X); // MbrXMax = -1000 + 500
+        Assert.Equal(-1500.0, result.Coordinates[2].Y); // MbrYMax
+        Assert.Equal(-500.0, result.Coordinates[3].X); // MbrXMax
+        Assert.Equal(-2500.0, result.Coordinates[3].Y); // MbrYMin
+        Assert.Equal(-1500.0, result.Coordinates[4].X); // MbrXMin (closing coordinate)
+        Assert.Equal(-2500.0, result.Coordinates[4].Y); // MbrYMin (closing coordinate)
+    }
+
+    [Fact]
+    public void CreateBBOXPolygonFromPlaceGeometry_PostcodeCaseInsensitive_CalculatesMBRWithRadius()
+    {
+        // Arrange - Test with different case
+        var place = new GazetteerEntry
+        {
+            LocalType = "POSTCODE",
+            GeometryX = 1000m,
+            GeometryY = 2000m,
+            MbrXMin = 100m,
+            MbrXMax = 200m,
+            MbrYMin = 300m,
+            MbrYMax = 400m
+        };
+
+        // Act
+        var result = PlaceGeometryHelper.CreateBBOXPolygonFromPlaceGeometry(place);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(27700, result.SRID);
+        // Based on the code, it's case-sensitive, so this should use provided MBR values
+        Assert.Equal(100.0, result.Coordinates[0].X); // Uses provided MbrXMin
+        Assert.Equal(300.0, result.Coordinates[0].Y); // Uses provided MbrYMin
+    }
+
+    [Fact]
+    public void CreateBBOXPolygonFromPlaceGeometry_LargeDecimalValues_ConvertsToDoubleCorrectly()
+    {
+        // Arrange
+        var place = new GazetteerEntry
+        {
+            LocalType = "Village",
+            GeometryX = 999999m,
+            GeometryY = 888888m,
+            MbrXMin = 100000.5m,
+            MbrXMax = 200000.75m,
+            MbrYMin = 300000.25m,
+            MbrYMax = 400000.99m
+        };
+
+        // Act
+        var result = PlaceGeometryHelper.CreateBBOXPolygonFromPlaceGeometry(place);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(27700, result.SRID);
+        Assert.Equal(5, result.Coordinates.Length);
+        
+        // Verify decimal to double conversion
+        Assert.Equal(100000.5, result.Coordinates[0].X, precision: 10);
+        Assert.Equal(300000.25, result.Coordinates[0].Y, precision: 10);
+        Assert.Equal(100000.5, result.Coordinates[1].X, precision: 10);
+        Assert.Equal(400000.99, result.Coordinates[1].Y, precision: 10);
+        Assert.Equal(200000.75, result.Coordinates[2].X, precision: 10);
+        Assert.Equal(400000.99, result.Coordinates[2].Y, precision: 10);
+        Assert.Equal(200000.75, result.Coordinates[3].X, precision: 10);
+        Assert.Equal(300000.25, result.Coordinates[3].Y, precision: 10);
+        Assert.Equal(100000.5, result.Coordinates[4].X, precision: 10);
+        Assert.Equal(300000.25, result.Coordinates[4].Y, precision: 10);
+    }
+
+    [Fact]
+    public void CreateBBOXPolygonFromPlaceGeometry_ZeroGeometryCoordinates_CalculatesMBRCorrectly()
+    {
+        // Arrange
+        var place = new GazetteerEntry
+        {
+            LocalType = "Postcode",
+            GeometryX = 0m,
+            GeometryY = 0m,
+            MbrXMin = 0m,
+            MbrXMax = 0m,
+            MbrYMin = 0m,
+            MbrYMax = 0m
+        };
+
+        // Act
+        var result = PlaceGeometryHelper.CreateBBOXPolygonFromPlaceGeometry(place);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(27700, result.SRID);
+        Assert.Equal(5, result.Coordinates.Length);
+        
+        // Verify the coordinates are based on calculated MBR (0 ± 500)
+        Assert.Equal(-500.0, result.Coordinates[0].X); // MbrXMin = 0 - 500
+        Assert.Equal(-500.0, result.Coordinates[0].Y); // MbrYMin = 0 - 500
+        Assert.Equal(-500.0, result.Coordinates[1].X); // MbrXMin
+        Assert.Equal(500.0, result.Coordinates[1].Y); // MbrYMax = 0 + 500
+        Assert.Equal(500.0, result.Coordinates[2].X); // MbrXMax = 0 + 500
+        Assert.Equal(500.0, result.Coordinates[2].Y); // MbrYMax
+        Assert.Equal(500.0, result.Coordinates[3].X); // MbrXMax
+        Assert.Equal(-500.0, result.Coordinates[3].Y); // MbrYMin
+        Assert.Equal(-500.0, result.Coordinates[4].X); // MbrXMin (closing coordinate)
+        Assert.Equal(-500.0, result.Coordinates[4].Y); // MbrYMin (closing coordinate)
+    }
+}

--- a/CSIDE.Web/CSIDE.Web.csproj
+++ b/CSIDE.Web/CSIDE.Web.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="GovukNotify" Version="8.1.0" />
     <PackageReference Include="Humanizer.Core" Version="3.0.10" />
     <PackageReference Include="Markdig" Version="1.3.2" />
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.108">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.122">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -36,8 +36,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageReference Include="Microsoft.Graph" Version="6.2.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.10.0" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.10.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.12.2" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.12.2" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.10.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.4.0" />


### PR DESCRIPTION
This PR allows the 'Location' parameter of the Landowner Deposits, PPOs and DMMOs Search APIs to accept Postcodes. Since postcodes don't return bounding rectangle, a rectangle is generated by applying a 500m buffer around the returned point.

This PR also fixes an issue where searching for a location that doesn't exist would return all the results from the database, due to the way null results from the places service were handled.

Closes #59 